### PR TITLE
[fix] ECR latest 태그 및 ECS 네트워크 모드 수정

### DIFF
--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -36,9 +36,11 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
-        # 커밋 SHA를 태그로 사용해 이미지 빌드 후 ECR에 push
+        # 커밋 SHA + latest 태그로 이미지 빌드 후 ECR에 push
 
       - name: Fill in the new image ID in the ECS task definition
         id: task-def

--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -2,9 +2,8 @@
   "family": "home-protect-server-task",
   "taskRoleArn": "arn:aws:iam::641628981583:role/ecsTaskExecutionRole",
   "executionRoleArn": "arn:aws:iam::641628981583:role/ecsTaskExecutionRole",
-  "networkMode": "awsvpc",
+  "networkMode": "bridge",
   "requiresCompatibilities": ["EC2"],
-  "cpu": "512",
   "containerDefinitions": [
     {
       "name": "home-protect-server",
@@ -13,6 +12,7 @@
       "portMappings": [
         {
           "containerPort": 8080,
+          "hostPort": 8080,
           "protocol": "tcp"
         }
       ],


### PR DESCRIPTION
## #️⃣ 관련 이슈

- Closes #2

## ⏰ 작업 시간

- 예상 작업 시간 : -
- 실제 작업 시간 : 1h

## 💻 작업 내용

- back-deploy.yml에 ECR latest 태그 함께 push하도록 수정
- task-definition.json 네트워크 모드 awsvpc → bridge 변경
- task-definition.json hostPort 8080 추가

## 🪏 작업하면서 고민한 부분

- EC2 환경에서 awsvpc 모드는 태스크가 프라이빗 IP만 가져서 외부 접근 불가 → bridge로 변경
- Actions에서 커밋 SHA 태그로만 push해 latest 이미지를 못 찾는 문제 발생 → latest 태그 함께 push

## 👀 리뷰 포인트

- 없음

## 📘 참고 자료

- 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 파이프라인에서 Docker 이미지에 커밋 SHA 태그와 함께 최신(latest) 태그를 추가로 생성하고 배포하도록 개선
  * 컨테이너 네트워킹 모드를 변경하고 호스트 포트 바인딩 구성을 업데이트하여 배포 인프라 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->