### PR TITLE
[feat] 실거래가 공공 API 구현 (#17)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'home-protect'

--- a/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
@@ -1,0 +1,94 @@
+package com.example.homeprotect.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class RealTradeApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(RealTradeApiClient.class);
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Value("${public-api.external.seoul-real-trade-url}")
+    private String baseUrl;
+
+    @Value("${public-api.external.seoul-real-trade-key}")
+    private String apiKey;
+
+    @Value("${public-api.external.seoul-real-trade-service}")
+    private String serviceName;
+
+    private final WebClient webClient;
+
+    public RealTradeApiClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.clone().build();
+    }
+
+    public Mono<Long> fetchAverageTradeAmount(String cggCd, String bldgUsg) {
+        String cutoffDate = LocalDate.now().minusYears(2).format(DATE_FMT);
+        String thisYear = String.valueOf(LocalDate.now().getYear());
+        String lastYear = String.valueOf(LocalDate.now().getYear() - 1);
+
+        Mono<List<Long>> thisYearData = fetchTradeByYear(thisYear, cggCd, bldgUsg, cutoffDate);
+        Mono<List<Long>> lastYearData = fetchTradeByYear(lastYear, cggCd, bldgUsg, cutoffDate);
+
+        return Mono.zip(thisYearData, lastYearData)
+            .map(tuple -> {
+                List<Long> combined = new ArrayList<>(tuple.getT1());
+                combined.addAll(tuple.getT2());
+                return combined.stream().mapToLong(Long::longValue).sum()
+                    / Math.max(combined.size(), 1);
+            });
+    }
+
+    private Mono<List<Long>> fetchTradeByYear(String year, String cggCd, String bldgUsg, String cutoffDate) {
+        String uri = buildUri(year, cggCd, bldgUsg);
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .map(root -> parseTradeAmounts(root, cutoffDate, cggCd))
+            .onErrorResume(e -> {
+                log.error("서울시 매매 실거래가 API 호출 실패 [{}년]: {}", year, e.getMessage());
+                return Mono.just(new ArrayList<>());
+            });
+    }
+
+    private String buildUri(String year, String cggCd, String bldgUsg) {
+        UriComponentsBuilder builder = UriComponentsBuilder
+            .fromUriString(baseUrl)
+            .pathSegment(apiKey, "json", serviceName, "1", "1000", year, cggCd);
+        if (bldgUsg != null && !bldgUsg.isEmpty()) {
+            builder.pathSegment(bldgUsg);
+        }
+        return builder.build().encode(StandardCharsets.UTF_8).toUriString();
+    }
+
+    private List<Long> parseTradeAmounts(JsonNode root, String cutoffDate, String cggCd) {
+        List<Long> amounts = new ArrayList<>();
+        JsonNode rows = root.path(serviceName).path("row");
+        for (JsonNode row : rows) {
+            if (!cggCd.equals(row.path("CGG_CD").asText())) continue;
+            if (row.path("CTRT_DAY").asText().compareTo(cutoffDate) < 0) continue;
+            double amt = row.path("THING_AMT").asDouble();
+            if (amt > 0) amounts.add((long) (amt * 10_000));
+        }
+        return amounts;
+    }
+
+
+}

--- a/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
@@ -7,7 +7,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -22,6 +22,7 @@ public class RealTradeApiClient {
 
     private static final Logger log = LoggerFactory.getLogger(RealTradeApiClient.class);
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final int PAGE_SIZE = 1000;
 
     @Value("${public-api.external.seoul-real-trade-url}")
     private String baseUrl;
@@ -56,22 +57,53 @@ public class RealTradeApiClient {
     }
 
     private Mono<List<Long>> fetchTradeByYear(String year, String cggCd, String bldgUsg, String cutoffDate) {
-        String uri = buildUri(year, cggCd, bldgUsg);
-        return webClient.get()
-            .uri(uri)
-            .retrieve()
-            .bodyToMono(JsonNode.class)
-            .map(root -> parseTradeAmounts(root, cutoffDate, cggCd))
+        return fetchPage(1, PAGE_SIZE, year, cggCd, bldgUsg)
+            .flatMap(root -> {
+                List<Long> firstPage = parseTradeAmounts(root, cutoffDate, cggCd);
+                int totalCount = root.path(serviceName).path("list_total_count").asInt();
+                if (totalCount <= PAGE_SIZE) {
+                    return Mono.just(firstPage);
+                }
+                int totalPages = (int) Math.ceil((double) totalCount / PAGE_SIZE);
+                List<Mono<List<Long>>> remainingMonos = new ArrayList<>();
+                for (int page = 2; page <= totalPages; page++) {
+                    int start = (page - 1) * PAGE_SIZE + 1;
+                    int end = page * PAGE_SIZE;
+                    final int p = page;
+                    remainingMonos.add(fetchPage(start, end, year, cggCd, bldgUsg)
+                        .map(r -> parseTradeAmounts(r, cutoffDate, cggCd))
+                        .onErrorResume(e -> {
+                            log.error("서울시 매매 실거래가 API 호출 실패 [{}년 {}페이지]: {}", year, p, e.getMessage());
+                            return Mono.just(new ArrayList<>());
+                        }));
+                }
+                return Flux.merge(remainingMonos)
+                    .collectList()
+                    .map(lists -> {
+                        List<Long> all = new ArrayList<>(firstPage);
+                        lists.forEach(all::addAll);
+                        return all;
+                    });
+            })
             .onErrorResume(e -> {
                 log.error("서울시 매매 실거래가 API 호출 실패 [{}년]: {}", year, e.getMessage());
                 return Mono.just(new ArrayList<>());
             });
     }
 
-    private String buildUri(String year, String cggCd, String bldgUsg) {
+    private Mono<JsonNode> fetchPage(int start, int end, String year, String cggCd, String bldgUsg) {
+        String uri = buildUri(start, end, year, cggCd, bldgUsg);
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(JsonNode.class);
+    }
+
+    private String buildUri(int start, int end, String year, String cggCd, String bldgUsg) {
         UriComponentsBuilder builder = UriComponentsBuilder
             .fromUriString(baseUrl)
-            .pathSegment(apiKey, "json", serviceName, "1", "1000", year, cggCd);
+            .pathSegment(apiKey, "json", serviceName,
+                String.valueOf(start), String.valueOf(end), year, cggCd);
         if (bldgUsg != null && !bldgUsg.isEmpty()) {
             builder.pathSegment(bldgUsg);
         }
@@ -89,6 +121,4 @@ public class RealTradeApiClient {
         }
         return amounts;
     }
-
-
 }

--- a/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
@@ -40,17 +40,21 @@ public class RealTradeApiClient {
     }
 
     public Mono<Long> fetchAverageTradeAmount(String cggCd, String bldgUsg) {
-        String cutoffDate = LocalDate.now().minusYears(2).format(DATE_FMT);
-        String thisYear = String.valueOf(LocalDate.now().getYear());
-        String lastYear = String.valueOf(LocalDate.now().getYear() - 1);
+        LocalDate today = LocalDate.now();
+        String cutoffDate = today.minusYears(2).format(DATE_FMT);
+        String thisYear = String.valueOf(today.getYear());
+        String lastYear = String.valueOf(today.getYear() - 1);
+        String twoYearsAgo = String.valueOf(today.getYear() - 2);
 
         Mono<List<Long>> thisYearData = fetchTradeByYear(thisYear, cggCd, bldgUsg, cutoffDate);
         Mono<List<Long>> lastYearData = fetchTradeByYear(lastYear, cggCd, bldgUsg, cutoffDate);
+        Mono<List<Long>> twoYearsAgoData = fetchTradeByYear(twoYearsAgo, cggCd, bldgUsg, cutoffDate);
 
-        return Mono.zip(thisYearData, lastYearData)
+        return Mono.zip(thisYearData, lastYearData, twoYearsAgoData)
             .map(tuple -> {
                 List<Long> combined = new ArrayList<>(tuple.getT1());
                 combined.addAll(tuple.getT2());
+                combined.addAll(tuple.getT3());
                 return combined.stream().mapToLong(Long::longValue).sum()
                     / Math.max(combined.size(), 1);
             });

--- a/src/main/java/com/example/homeprotect/client/RentApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RentApiClient.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
-
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -22,6 +22,7 @@ public class RentApiClient {
 
     private static final Logger log = LoggerFactory.getLogger(RentApiClient.class);
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final int PAGE_SIZE = 1000;
 
     @Value("${public-api.external.seoul-rent-url}")
     private String baseUrl;
@@ -62,22 +63,53 @@ public class RentApiClient {
 
     private Mono<List<Long>> fetchByYear(String year, String cggCd, String stdgCd,
         String mno, String sno, String bldgUsg, String cutoffDate) {
-        String uri = buildUri(year, cggCd, bldgUsg);
-        return webClient.get()
-            .uri(uri)
-            .retrieve()
-            .bodyToMono(JsonNode.class)
-            .map(root -> parseJeonseAmounts(root, cutoffDate, cggCd, stdgCd, mno, sno)) // 파라미터 다 넘겨요
+        return fetchPage(1, PAGE_SIZE, year, cggCd, bldgUsg)
+            .flatMap(root -> {
+                List<Long> firstPage = parseJeonseAmounts(root, cutoffDate, cggCd, stdgCd, mno, sno);
+                int totalCount = root.path(serviceName).path("list_total_count").asInt();
+                if (totalCount <= PAGE_SIZE) {
+                    return Mono.just(firstPage);
+                }
+                int totalPages = (int) Math.ceil((double) totalCount / PAGE_SIZE);
+                List<Mono<List<Long>>> remainingMonos = new ArrayList<>();
+                for (int page = 2; page <= totalPages; page++) {
+                    int start = (page - 1) * PAGE_SIZE + 1;
+                    int end = page * PAGE_SIZE;
+                    final int p = page;
+                    remainingMonos.add(fetchPage(start, end, year, cggCd, bldgUsg)
+                        .map(r -> parseJeonseAmounts(r, cutoffDate, cggCd, stdgCd, mno, sno))
+                        .onErrorResume(e -> {
+                            log.error("서울시 전월세가 API 호출 실패 [{}년 {}페이지]: {}", year, p, e.getMessage());
+                            return Mono.just(new ArrayList<>());
+                        }));
+                }
+                return Flux.merge(remainingMonos)
+                    .collectList()
+                    .map(lists -> {
+                        List<Long> all = new ArrayList<>(firstPage);
+                        lists.forEach(all::addAll);
+                        return all;
+                    });
+            })
             .onErrorResume(e -> {
                 log.error("서울시 전월세가 API 호출 실패 [{}년]: {}", year, e.getMessage());
                 return Mono.just(new ArrayList<>());
             });
     }
 
-    private String buildUri(String year, String cggCd, String bldgUsg) {
+    private Mono<JsonNode> fetchPage(int start, int end, String year, String cggCd, String bldgUsg) {
+        String uri = buildUri(start, end, year, cggCd, bldgUsg);
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(JsonNode.class);
+    }
+
+    private String buildUri(int start, int end, String year, String cggCd, String bldgUsg) {
         UriComponentsBuilder builder = UriComponentsBuilder
             .fromUriString(baseUrl)
-            .pathSegment(apiKey, "json", serviceName, "1", "1000", year, cggCd);
+            .pathSegment(apiKey, "json", serviceName,
+                String.valueOf(start), String.valueOf(end), year, cggCd);
         if (bldgUsg != null && !bldgUsg.isEmpty()) {
             builder.pathSegment(bldgUsg);
         }
@@ -91,13 +123,10 @@ public class RentApiClient {
         JsonNode rows = root.path(serviceName).path("row");
         for (JsonNode row : rows) {
             if (!cggCd.equals(row.path("CGG_CD").asText())) continue;
-            // stdgCd 있으면 법정동 필터
             if (stdgCd != null && !stdgCd.isEmpty()
                 && !stdgCd.equals(row.path("STDG_CD").asText())) continue;
-            // mno 있으면 본번 필터
             if (mno != null && !mno.isEmpty()
                 && !mno.equals(row.path("MNO").asText())) continue;
-            // sno 있으면 부번 필터
             if (sno != null && !sno.isEmpty()
                 && !sno.equals(row.path("SNO").asText())) continue;
             if (!jeonseTypeValue.equals(row.path(rentTypeField).asText())) continue;

--- a/src/main/java/com/example/homeprotect/client/RentApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RentApiClient.java
@@ -1,0 +1,110 @@
+package com.example.homeprotect.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class RentApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(RentApiClient.class);
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Value("${public-api.external.seoul-rent-url}")
+    private String baseUrl;
+
+    @Value("${public-api.external.seoul-rent-key}")
+    private String apiKey;
+
+    @Value("${public-api.external.seoul-rent-service}")
+    private String serviceName;
+
+    @Value("${public-api.external.seoul-rent-type-field}")
+    private String rentTypeField;
+
+    @Value("${public-api.external.seoul-rent-type-jeonse}")
+    private String jeonseTypeValue;
+
+    private final WebClient webClient;
+
+    public RentApiClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.clone().build();
+    }
+
+    public Mono<List<Long>> fetchJeonseAmounts(String cggCd, String stdgCd, String mno, String sno, String bldgUsg) {
+        String cutoffDate = LocalDate.now().minusYears(2).format(DATE_FMT);
+        String thisYear = String.valueOf(LocalDate.now().getYear());
+        String lastYear = String.valueOf(LocalDate.now().getYear() - 1);
+
+        Mono<List<Long>> thisYearData = fetchByYear(thisYear, cggCd, stdgCd, mno, sno, bldgUsg, cutoffDate);
+        Mono<List<Long>> lastYearData = fetchByYear(lastYear, cggCd, stdgCd, mno, sno, bldgUsg, cutoffDate);
+
+        return Mono.zip(thisYearData, lastYearData)
+            .map(tuple -> {
+                List<Long> combined = new ArrayList<>(tuple.getT1());
+                combined.addAll(tuple.getT2());
+                return combined;
+            });
+    }
+
+    private Mono<List<Long>> fetchByYear(String year, String cggCd, String stdgCd,
+        String mno, String sno, String bldgUsg, String cutoffDate) {
+        String uri = buildUri(year, cggCd, bldgUsg);
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .map(root -> parseJeonseAmounts(root, cutoffDate, cggCd, stdgCd, mno, sno)) // 파라미터 다 넘겨요
+            .onErrorResume(e -> {
+                log.error("서울시 전월세가 API 호출 실패 [{}년]: {}", year, e.getMessage());
+                return Mono.just(new ArrayList<>());
+            });
+    }
+
+    private String buildUri(String year, String cggCd, String bldgUsg) {
+        UriComponentsBuilder builder = UriComponentsBuilder
+            .fromUriString(baseUrl)
+            .pathSegment(apiKey, "json", serviceName, "1", "1000", year, cggCd);
+        if (bldgUsg != null && !bldgUsg.isEmpty()) {
+            builder.pathSegment(bldgUsg);
+        }
+        return builder.build().encode(StandardCharsets.UTF_8).toUriString();
+    }
+
+    private List<Long> parseJeonseAmounts(JsonNode root, String cutoffDate,
+        String cggCd, String stdgCd,
+        String mno, String sno) {
+        List<Long> amounts = new ArrayList<>();
+        JsonNode rows = root.path(serviceName).path("row");
+        for (JsonNode row : rows) {
+            if (!cggCd.equals(row.path("CGG_CD").asText())) continue;
+            // stdgCd 있으면 법정동 필터
+            if (stdgCd != null && !stdgCd.isEmpty()
+                && !stdgCd.equals(row.path("STDG_CD").asText())) continue;
+            // mno 있으면 본번 필터
+            if (mno != null && !mno.isEmpty()
+                && !mno.equals(row.path("MNO").asText())) continue;
+            // sno 있으면 부번 필터
+            if (sno != null && !sno.isEmpty()
+                && !sno.equals(row.path("SNO").asText())) continue;
+            if (!jeonseTypeValue.equals(row.path(rentTypeField).asText())) continue;
+            if (row.path("CTRT_DAY").asText().compareTo(cutoffDate) < 0) continue;
+            double grfe = row.path("GRFE").asDouble();
+            if (grfe > 0) amounts.add((long) (grfe * 10_000));
+        }
+        return amounts;
+    }
+}

--- a/src/main/java/com/example/homeprotect/client/RentApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RentApiClient.java
@@ -46,17 +46,21 @@ public class RentApiClient {
     }
 
     public Mono<List<Long>> fetchJeonseAmounts(String cggCd, String stdgCd, String mno, String sno, String bldgUsg) {
-        String cutoffDate = LocalDate.now().minusYears(2).format(DATE_FMT);
-        String thisYear = String.valueOf(LocalDate.now().getYear());
-        String lastYear = String.valueOf(LocalDate.now().getYear() - 1);
+        LocalDate today = LocalDate.now();
+        String cutoffDate = today.minusYears(2).format(DATE_FMT);
+        String thisYear = String.valueOf(today.getYear());
+        String lastYear = String.valueOf(today.getYear() - 1);
+        String twoYearsAgo = String.valueOf(today.getYear() - 2);
 
         Mono<List<Long>> thisYearData = fetchByYear(thisYear, cggCd, stdgCd, mno, sno, bldgUsg, cutoffDate);
         Mono<List<Long>> lastYearData = fetchByYear(lastYear, cggCd, stdgCd, mno, sno, bldgUsg, cutoffDate);
+        Mono<List<Long>> twoYearsAgoData = fetchByYear(twoYearsAgo, cggCd, stdgCd, mno, sno, bldgUsg, cutoffDate);
 
-        return Mono.zip(thisYearData, lastYearData)
+        return Mono.zip(thisYearData, lastYearData, twoYearsAgoData)
             .map(tuple -> {
                 List<Long> combined = new ArrayList<>(tuple.getT1());
                 combined.addAll(tuple.getT2());
+                combined.addAll(tuple.getT3());
                 return combined;
             });
     }

--- a/src/main/java/com/example/homeprotect/config/WebClientConfig.java
+++ b/src/main/java/com/example/homeprotect/config/WebClientConfig.java
@@ -24,9 +24,12 @@ public class WebClientConfig {
         HttpClient httpClient = buildHttpClient(CONNECTION_TIMEOUT_MS, RESPONSE_TIMEOUT_MS);
 
         return WebClient.builder()
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-                .clientConnector(new ReactorClientHttpConnector(httpClient));
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .codecs(configurer -> configurer
+                .defaultCodecs()
+                .maxInMemorySize(10 * 1024 * 1024)); // 10MB로 늘리기
     }
 
     static HttpClient buildHttpClient(int connectTimeoutMs, int responseTimeoutMs) {
@@ -36,4 +39,5 @@ public class WebClientConfig {
                 .doOnConnected(conn -> conn.addHandlerLast(
                         new ReadTimeoutHandler(responseTimeoutMs, TimeUnit.MILLISECONDS)));
     }
+
 }

--- a/src/main/java/com/example/homeprotect/dto/redis/InitSessionData.java
+++ b/src/main/java/com/example/homeprotect/dto/redis/InitSessionData.java
@@ -14,6 +14,8 @@ public class InitSessionData {
     private String address;
     private String admCd;
     private String rnMgtSn;
+    private String mno;
+    private String sno;
     private Long deposit;
     private Long monthlyRent;
     private String contractType;

--- a/src/main/java/com/example/homeprotect/dto/request/AnalysisInitRequest.java
+++ b/src/main/java/com/example/homeprotect/dto/request/AnalysisInitRequest.java
@@ -16,6 +16,8 @@ public class AnalysisInitRequest {
     private String address;
     private String admCd;
     private String rnMgtSn;
+    private String mno;
+    private String sno;
     private Long deposit;
     private Long monthlyRent;
     private String contractType;

--- a/src/main/java/com/example/homeprotect/dto/response/AddressResponse.java
+++ b/src/main/java/com/example/homeprotect/dto/response/AddressResponse.java
@@ -12,4 +12,6 @@ public class AddressResponse {
     private String buildingName;
     private String admCd;
     private String rnMgtSn;
+    private String mno;
+    private String sno;
 }

--- a/src/main/java/com/example/homeprotect/dto/response/JeonseRatioResponse.java
+++ b/src/main/java/com/example/homeprotect/dto/response/JeonseRatioResponse.java
@@ -1,0 +1,25 @@
+package com.example.homeprotect.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+public class JeonseRatioResponse {
+
+    private String ratioType;
+    private Long recentHigh;
+    private Long recentLow;
+    private Long average;
+    private Long convertedDeposit;
+    private Double ratioPercent;
+    private Integer sampleCount;
+    private Boolean lowReliability;
+    private String riskLevel;
+}

--- a/src/main/java/com/example/homeprotect/service/AddressService.java
+++ b/src/main/java/com/example/homeprotect/service/AddressService.java
@@ -94,6 +94,8 @@ public class AddressService {
                 .buildingName(juso.path("bdNm").asText())
                 .admCd(juso.path("admCd").asText())
                 .rnMgtSn(juso.path("rnMgtSn").asText())
+                .mno(String.format("%04d", juso.path("buldMnnm").asInt()))  // 추가
+                .sno(String.format("%04d", juso.path("buldSlno").asInt()))  // 추가
                 .build());
         }
         return results;

--- a/src/main/java/com/example/homeprotect/service/AddressService.java
+++ b/src/main/java/com/example/homeprotect/service/AddressService.java
@@ -63,7 +63,7 @@ public class AddressService {
     }
 
     private URI buildUri(String keyword) {
-        return UriComponentsBuilder.fromHttpUrl(moisAddressUrl)
+        return UriComponentsBuilder.fromUriString(moisAddressUrl)
             .queryParam("confmKey", moisAddressKey)
             .queryParam("currentPage", 1)
             .queryParam("countPerPage", 10)

--- a/src/main/java/com/example/homeprotect/service/AnalysisService.java
+++ b/src/main/java/com/example/homeprotect/service/AnalysisService.java
@@ -3,6 +3,8 @@ package com.example.homeprotect.service;
 import java.util.Set;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.example.homeprotect.dto.redis.InitSessionData;
@@ -12,16 +14,20 @@ import com.example.homeprotect.exception.HomeProtectException;
 import com.example.homeprotect.util.RedisUtil;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Service
 public class AnalysisService {
 
+    private static final Logger log = LoggerFactory.getLogger(AnalysisService.class);
     private static final Set<String> VALID_CONTRACT_TYPES = Set.of("jeonse", "half_jeonse", "monthly");
 
     private final RedisUtil redisUtil;
+    private final JeonseRatioService jeonseRatioService;
 
-    public AnalysisService(RedisUtil redisUtil) {
+    public AnalysisService(RedisUtil redisUtil, JeonseRatioService jeonseRatioService) {
         this.redisUtil = redisUtil;
+        this.jeonseRatioService = jeonseRatioService;
     }
 
     public Mono<String> initAnalysis(AnalysisInitRequest request, String ocrSessionId) {
@@ -34,11 +40,24 @@ public class AnalysisService {
                 .address(request.getAddress())
                 .admCd(request.getAdmCd())
                 .rnMgtSn(request.getRnMgtSn())
+                .mno(request.getMno())
+                .sno(request.getSno())
                 .deposit(request.getDeposit())
                 .monthlyRent(request.getMonthlyRent())
                 .contractType(request.getContractType())
                 .contractPeriod(request.getContractPeriod())
                 .build();
-        return redisUtil.saveInitSession(sessionData).thenReturn(sessionData.getSessionId());
+        return redisUtil.saveInitSession(sessionData)
+                .doOnSuccess(v ->
+                        jeonseRatioService.calculateAndSave(sessionData)
+                                .onErrorResume(e -> {
+                                    log.error("전세가율 백그라운드 계산 실패 [{}]: {}",
+                                            sessionData.getSessionId(), e.getMessage());
+                                    return Mono.empty();
+                                })
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .subscribe()
+                )
+                .thenReturn(sessionData.getSessionId());
     }
 }

--- a/src/main/java/com/example/homeprotect/service/JeonseRatioService.java
+++ b/src/main/java/com/example/homeprotect/service/JeonseRatioService.java
@@ -1,0 +1,122 @@
+package com.example.homeprotect.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.homeprotect.client.RealTradeApiClient;
+import com.example.homeprotect.client.RentApiClient;
+import com.example.homeprotect.dto.redis.InitSessionData;
+import com.example.homeprotect.dto.response.JeonseRatioResponse;
+import com.example.homeprotect.util.RedisUtil;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+public class JeonseRatioService {
+
+    private final RentApiClient rentApiClient;
+    private final RealTradeApiClient realTradeApiClient;
+    private final RedisUtil redisUtil;
+
+    public JeonseRatioService(RentApiClient rentApiClient,
+                               RealTradeApiClient realTradeApiClient,
+                               RedisUtil redisUtil) {
+        this.rentApiClient = rentApiClient;
+        this.realTradeApiClient = realTradeApiClient;
+        this.redisUtil = redisUtil;
+    }
+
+    public Mono<Void> calculateAndSave(InitSessionData sessionData) {
+        if ("monthly".equals(sessionData.getContractType())) {
+            JeonseRatioResponse monthly = JeonseRatioResponse.builder()
+                    .ratioType("monthly")
+                    .build();
+            return redisUtil.saveJeonseRatio(sessionData.getSessionId(), monthly);
+        }
+
+        String cggCd = sessionData.getAdmCd().substring(0, 5);
+        String stdgCd = sessionData.getAdmCd().substring(5, 10);
+        String mno = sessionData.getMno();
+        String sno = sessionData.getSno();
+        String bldgUsg = parseBldgUsg(sessionData.getAddress());
+
+        Mono<List<Long>> jeonseAmountsMono =
+            // 1차: 건물 단위
+            rentApiClient.fetchJeonseAmounts(cggCd, stdgCd, mno, sno, bldgUsg)
+                .flatMap(amounts -> {
+                    if (amounts.size() >= 3) return Mono.just(amounts);
+                    // 2차: 법정동 단위로 확장
+                    return rentApiClient.fetchJeonseAmounts(cggCd, stdgCd, null, null, bldgUsg);
+                })
+                .flatMap(amounts -> {
+                    if (amounts.size() >= 3) return Mono.just(amounts);
+                    // 3차: 구 단위로 확장
+                    return rentApiClient.fetchJeonseAmounts(cggCd, null, null, null, bldgUsg);
+                });
+
+        return Mono.zip(jeonseAmountsMono, realTradeApiClient.fetchAverageTradeAmount(cggCd, bldgUsg))
+                .flatMap(tuple -> {
+                    List<Long> jeonseAmounts = tuple.getT1();
+                    long avgTradeAmount = tuple.getT2();
+                    JeonseRatioResponse response = buildResponse(sessionData, jeonseAmounts, avgTradeAmount);
+                    return redisUtil.saveJeonseRatio(sessionData.getSessionId(), response);
+                });
+    }
+
+    private JeonseRatioResponse buildResponse(InitSessionData data, List<Long> jeonseAmounts, long avgTradeAmount) {
+        int sampleCount = jeonseAmounts.size();
+        long recentHigh = jeonseAmounts.stream().mapToLong(Long::longValue).max().orElse(0L);
+        long recentLow = jeonseAmounts.stream().mapToLong(Long::longValue).min().orElse(0L);
+        long average = sampleCount > 0
+                ? jeonseAmounts.stream().mapToLong(Long::longValue).sum() / sampleCount
+                : 0L;
+
+        long convertedDeposit = calcConvertedDeposit(data);
+
+        Double ratioPercent = (convertedDeposit > 0 && avgTradeAmount > 0)
+            ? (double) convertedDeposit / avgTradeAmount * 100
+            : null;
+
+        boolean lowReliability = sampleCount < 3;
+        String riskLevel = resolveRiskLevel(ratioPercent);
+
+        return JeonseRatioResponse.builder()
+                .ratioType(data.getContractType())
+                .recentHigh(recentHigh)
+                .recentLow(recentLow)
+                .average(average)
+                .convertedDeposit(convertedDeposit)
+                .ratioPercent(ratioPercent)
+                .sampleCount(sampleCount)
+                .lowReliability(lowReliability)
+                .riskLevel(riskLevel)
+                .build();
+    }
+
+    private long calcConvertedDeposit(InitSessionData data) {
+        long deposit = data.getDeposit() != null ? data.getDeposit() : 0L;
+        if ("half_jeonse".equals(data.getContractType())) {
+            long monthlyRent = data.getMonthlyRent() != null ? data.getMonthlyRent() : 0L;
+            return deposit + (long) (monthlyRent * 12 / 0.0475);
+        }
+        return deposit;
+    }
+
+    private String resolveRiskLevel(Double ratioPercent) {
+        if (ratioPercent == null) return null;
+        if (ratioPercent >= 80) return "danger";
+        if (ratioPercent >= 60) return "caution";
+        return "safe";
+    }
+
+    // 도로명 주소에는 건물 유형이 없는 경우가 많으므로 미인식 시 빈 문자열 반환 (BLDG_USG 필터 없이 전체 조회)
+    private String parseBldgUsg(String address) {
+        if (address == null) return "";
+        if (address.contains("오피스텔")) return "오피스텔";
+        if (address.contains("연립") || address.contains("다세대") || address.contains("빌라")) return "연립다세대";
+        if (address.contains("단독") || address.contains("다가구")) return "단독다가구";
+        if (address.contains("아파트") || address.contains("APT") || address.contains("apt")) return "아파트";
+        return "";
+    }
+}

--- a/src/main/java/com/example/homeprotect/service/JeonseRatioService.java
+++ b/src/main/java/com/example/homeprotect/service/JeonseRatioService.java
@@ -35,8 +35,12 @@ public class JeonseRatioService {
             return redisUtil.saveJeonseRatio(sessionData.getSessionId(), monthly);
         }
 
-        String cggCd = sessionData.getAdmCd().substring(0, 5);
-        String stdgCd = sessionData.getAdmCd().substring(5, 10);
+        String admCd = sessionData.getAdmCd();
+        if (admCd == null || admCd.length() < 10) {
+            return Mono.error(new IllegalArgumentException("admCd가 null이거나 10자 미만입니다: " + admCd));
+        }
+        String cggCd = admCd.substring(0, 5);
+        String stdgCd = admCd.substring(5, 10);
         String mno = sessionData.getMno();
         String sno = sessionData.getSno();
         String bldgUsg = parseBldgUsg(sessionData.getAddress());

--- a/src/main/java/com/example/homeprotect/util/RedisUtil.java
+++ b/src/main/java/com/example/homeprotect/util/RedisUtil.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.example.homeprotect.dto.redis.InitSessionData;
 import com.example.homeprotect.dto.redis.OcrSessionData;
+import com.example.homeprotect.dto.response.JeonseRatioResponse;
 import com.example.homeprotect.exception.ErrorCode;
 import com.example.homeprotect.exception.HomeProtectException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -19,6 +20,7 @@ public class RedisUtil {
 
     private static final String OCR_KEY_PREFIX = "ocr:";
     private static final String INIT_KEY_PREFIX = "init:";
+    private static final String JEONSE_RATIO_KEY_PREFIX = "jeonseRatio:";
     private static final Duration OCR_TTL = Duration.ofMinutes(30);
 
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
@@ -48,6 +50,20 @@ public class RedisUtil {
         return reactiveRedisTemplate.opsForValue().get(key)
                 .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
                 .flatMap(json -> deserialize(json, InitSessionData.class));
+    }
+
+    public Mono<Void> saveJeonseRatio(String sessionId, JeonseRatioResponse response) {
+        String key = JEONSE_RATIO_KEY_PREFIX + sessionId;
+        return serialize(response)
+                .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+                .then();
+    }
+
+    public Mono<JeonseRatioResponse> getJeonseRatio(String sessionId) {
+        String key = JEONSE_RATIO_KEY_PREFIX + sessionId;
+        return reactiveRedisTemplate.opsForValue().get(key)
+                .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
+                .flatMap(json -> deserialize(json, JeonseRatioResponse.class));
     }
 
     public Mono<OcrSessionData> getOcrSession(String sessionId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,12 +26,18 @@ public-api:
   external:
     # 1. 서울시: 부동산 실거래가 정보
     seoul-real-trade-url: http://openapi.seoul.go.kr:8088
+    seoul-real-trade-service: tbLnOpendataRtmsV
 
     # 2. 국토교통부: 건축물대장 서비스
     molit-building-url: https://apis.data.go.kr/1613000/BldRgstHubService
 
     # 3. 서울시: 부동산 전월세가 정보
     seoul-rent-url:  http://openapi.seoul.go.kr:8088
+    # 실제 서비스명 서울 열린데이터광장에서 확인 후 수정 필요
+    seoul-rent-service: tbLnOpendataRentV
+    # 전세/월세 구분 필드명·값
+    seoul-rent-type-field: RENT_SE
+    seoul-rent-type-jeonse: 전세
 
     # 4. 행정안전부: 실시간 주소정보 조회
     mois-address-url: https://business.juso.go.kr/addrlink/addrLinkApi.do

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,6 @@ public-api:
 
     # 3. 서울시: 부동산 전월세가 정보
     seoul-rent-url:  http://openapi.seoul.go.kr:8088
-    # 실제 서비스명 서울 열린데이터광장에서 확인 후 수정 필요
     seoul-rent-service: tbLnOpendataRentV
     # 전세/월세 구분 필드명·값
     seoul-rent-type-field: RENT_SE


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #17 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 3
- 실제 작업 시간 : 4

전세가율 계산 로직 오류로 인한 수정 진행
<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

서울 공공데이터 실거래가 API 구현
전세/월세 실거래가 조회 및 전세가율 계산 로직 구현

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- [트러블 슈팅1](링크)

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 전세 비율(Jeonse Ratio) 산출 및 저장 기능 추가: 전세/실거래 데이터를 결합해 위험도와 비율을 계산하여 세션에 저장합니다.
  * 외부 시범 데이터 조회 개선: 대량 페이지 처리로 더 많은 임대·실거래 샘플을 수집합니다.
  * 주소 응답에 물건 식별자(mno/sno) 포함으로 검색 정밀도 향상.
  * 비율 계산을 비동기 백그라운드에서 실행해 응답 지연 최소화.
* **기타**
  * HTTP 응답 버퍼 크기 확대(대용량 처리 지원).
  * Redis에 전세 비율 저장/조회 기능 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->