### PR TITLE
[feat] 건축물대장 공공 api 기능 구현 (#18)

### DIFF
--- a/src/main/java/com/example/homeprotect/client/BuildingApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/BuildingApiClient.java
@@ -13,6 +13,7 @@ import com.example.homeprotect.exception.ErrorCode;
 import com.example.homeprotect.exception.HomeProtectException;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -75,28 +76,28 @@ public class BuildingApiClient {
                 }
                 return hasRedevelopmentKeyword(items.path("jijiguCdNm").asText());
             })
-            .onErrorResume(e -> {
+            .onErrorMap(e -> {
                 log.error("건축물대장 지역지구구역 API 호출 실패: {}", e.getMessage());
-                return Mono.just(false);
+                return new HomeProtectException(ErrorCode.API_UNAVAILABLE, e);
             });
     }
 
     private Mono<JsonNode> callApi(String endpoint, String sigunguCd, String bjdongCd,
         String bun, String ji, int numOfRows) {
-        String uri = baseUrl + "/" + endpoint
-            + "?serviceKey=" + serviceKey
-            + "&sigunguCd=" + sigunguCd
-            + "&bjdongCd=" + bjdongCd
-            + "&bun=" + bun
-            + "&ji=" + ji
-            + "&_type=json"
-            + "&numOfRows=" + numOfRows
-            + "&pageNo=1";
+      String uri = baseUrl + "/" + endpoint
+          + "?serviceKey=" + serviceKey
+          + "&sigunguCd=" + sigunguCd
+          + "&bjdongCd=" + bjdongCd
+          + "&bun=" + bun
+          + "&ji=" + ji
+          + "&_type=json"
+          + "&numOfRows=" + numOfRows
+          + "&pageNo=1";
 
-        return webClient.get()
-            .uri(URI.create(uri))
-            .retrieve()
-            .bodyToMono(JsonNode.class);
+      return webClient.get()
+          .uri(URI.create(uri))
+          .retrieve()
+          .bodyToMono(JsonNode.class);
     }
 
     private boolean hasRedevelopmentKeyword(String value) {

--- a/src/main/java/com/example/homeprotect/client/BuildingApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/BuildingApiClient.java
@@ -1,0 +1,105 @@
+package com.example.homeprotect.client;
+
+import java.net.URI;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.example.homeprotect.exception.ErrorCode;
+import com.example.homeprotect.exception.HomeProtectException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class BuildingApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(BuildingApiClient.class);
+
+    private static final String TITLE_INFO_ENDPOINT = "getBrRecapTitleInfo";
+    private static final String JIGUJI_INFO_ENDPOINT = "getBrJijiguInfo";
+    private static final int TITLE_PAGE_SIZE = 10;
+    private static final int JIGUJI_PAGE_SIZE = 100;
+    private static final Set<String> REDEVELOPMENT_KEYWORDS =
+        Set.of("정비구역", "재개발", "재건축", "주거환경개선", "도시환경정비");
+
+    @Value("${public-api.external.molit-building-url}")
+    private String baseUrl;
+
+    @Value("${public-api.external.molit-building-key}")
+    private String serviceKey;
+
+    private final WebClient webClient;
+
+    public BuildingApiClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.clone().build();
+    }
+
+    public Mono<JsonNode> fetchTitleItem(String sigunguCd, String bjdongCd, String bun, String ji) {
+        return callApi(TITLE_INFO_ENDPOINT, sigunguCd, bjdongCd, bun, ji, TITLE_PAGE_SIZE)
+            .flatMap(root -> {
+                int totalCount = root.path("response").path("body").path("totalCount").asInt();
+                if (totalCount == 0) {
+                    return Mono.error(new HomeProtectException(ErrorCode.BUILDING_INFO_NOT_FOUND));
+                }
+                JsonNode items = root.path("response").path("body").path("items").path("item");
+                JsonNode item = items.isArray() ? items.get(0) : items;
+                if (item == null || item.isNull() || item.isMissingNode()) {
+                    return Mono.error(new HomeProtectException(ErrorCode.BUILDING_INFO_NOT_FOUND));
+                }
+                return Mono.just(item);
+            })
+            .onErrorMap(
+                e -> !(e instanceof HomeProtectException),
+                e -> {
+                    log.error("건축물대장 표제부 API 호출 실패: {}", e.getMessage());
+                    return new HomeProtectException(ErrorCode.API_UNAVAILABLE, e);
+                }
+            );
+    }
+
+    public Mono<Boolean> fetchIsRedevelopmentZone(String sigunguCd, String bjdongCd, String bun, String ji) {
+        return callApi(JIGUJI_INFO_ENDPOINT, sigunguCd, bjdongCd, bun, ji, JIGUJI_PAGE_SIZE)
+            .map(root -> {
+                JsonNode items = root.path("response").path("body").path("items").path("item");
+                if (items.isMissingNode() || items.isNull()) return false;
+                if (items.isArray()) {
+                    for (JsonNode item : items) {
+                        if (hasRedevelopmentKeyword(item.path("jijiguCdNm").asText())) return true;
+                    }
+                    return false;
+                }
+                return hasRedevelopmentKeyword(items.path("jijiguCdNm").asText());
+            })
+            .onErrorResume(e -> {
+                log.error("건축물대장 지역지구구역 API 호출 실패: {}", e.getMessage());
+                return Mono.just(false);
+            });
+    }
+
+    private Mono<JsonNode> callApi(String endpoint, String sigunguCd, String bjdongCd,
+        String bun, String ji, int numOfRows) {
+        String uri = baseUrl + "/" + endpoint
+            + "?serviceKey=" + serviceKey
+            + "&sigunguCd=" + sigunguCd
+            + "&bjdongCd=" + bjdongCd
+            + "&bun=" + bun
+            + "&ji=" + ji
+            + "&_type=json"
+            + "&numOfRows=" + numOfRows
+            + "&pageNo=1";
+
+        return webClient.get()
+            .uri(URI.create(uri))
+            .retrieve()
+            .bodyToMono(JsonNode.class);
+    }
+
+    private boolean hasRedevelopmentKeyword(String value) {
+        return REDEVELOPMENT_KEYWORDS.stream().anyMatch(value::contains);
+    }
+}

--- a/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
@@ -104,14 +104,14 @@ public class RealTradeApiClient {
     }
 
     private String buildUri(int start, int end, String year, String cggCd, String bldgUsg) {
-        UriComponentsBuilder builder = UriComponentsBuilder
-            .fromUriString(baseUrl)
-            .pathSegment(apiKey, "json", serviceName,
-                String.valueOf(start), String.valueOf(end), year, cggCd);
-        if (bldgUsg != null && !bldgUsg.isEmpty()) {
-            builder.pathSegment(bldgUsg);
-        }
-        return builder.build().encode(StandardCharsets.UTF_8).toUriString();
+      StringBuilder path = new StringBuilder("/")
+          .append(apiKey).append("/json/").append(serviceName).append("/")
+          .append(start).append("/").append(end).append("/")
+          .append(year).append("/").append(cggCd);
+      if (bldgUsg != null && !bldgUsg.isEmpty()) {
+        path.append("/").append(bldgUsg);
+      }
+      return baseUrl + path;
     }
 
     private List<Long> parseTradeAmounts(JsonNode root, String cutoffDate, String cggCd) {

--- a/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
@@ -1,7 +1,6 @@
 package com.example.homeprotect.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RealTradeApiClient.java
@@ -1,6 +1,7 @@
 package com.example.homeprotect.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import org.springframework.web.util.UriUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -107,9 +109,10 @@ public class RealTradeApiClient {
           .append(start).append("/").append(end).append("/")
           .append(year).append("/").append(cggCd);
       if (bldgUsg != null && !bldgUsg.isEmpty()) {
-        path.append("/").append(bldgUsg);
+        path.append("/").append(UriUtils.encodePath(bldgUsg, StandardCharsets.UTF_8));
       }
-      return baseUrl + path;
+      String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+      return base + path;
     }
 
     private List<Long> parseTradeAmounts(JsonNode root, String cutoffDate, String cggCd) {

--- a/src/main/java/com/example/homeprotect/client/RentApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RentApiClient.java
@@ -1,7 +1,6 @@
 package com.example.homeprotect.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/src/main/java/com/example/homeprotect/client/RentApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RentApiClient.java
@@ -1,6 +1,7 @@
 package com.example.homeprotect.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import org.springframework.web.util.UriUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -113,9 +115,10 @@ public class RentApiClient {
           .append(start).append("/").append(end).append("/")
           .append(year).append("/").append(cggCd);
       if (bldgUsg != null && !bldgUsg.isEmpty()) {
-        path.append("/").append(bldgUsg);
+        path.append("/").append(UriUtils.encodePath(bldgUsg, StandardCharsets.UTF_8));
       }
-      return baseUrl + path;
+      String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+      return base + path;
     }
 
     private List<Long> parseJeonseAmounts(JsonNode root, String cutoffDate,

--- a/src/main/java/com/example/homeprotect/client/RentApiClient.java
+++ b/src/main/java/com/example/homeprotect/client/RentApiClient.java
@@ -110,14 +110,14 @@ public class RentApiClient {
     }
 
     private String buildUri(int start, int end, String year, String cggCd, String bldgUsg) {
-        UriComponentsBuilder builder = UriComponentsBuilder
-            .fromUriString(baseUrl)
-            .pathSegment(apiKey, "json", serviceName,
-                String.valueOf(start), String.valueOf(end), year, cggCd);
-        if (bldgUsg != null && !bldgUsg.isEmpty()) {
-            builder.pathSegment(bldgUsg);
-        }
-        return builder.build().encode(StandardCharsets.UTF_8).toUriString();
+      StringBuilder path = new StringBuilder("/")
+          .append(apiKey).append("/json/").append(serviceName).append("/")
+          .append(start).append("/").append(end).append("/")
+          .append(year).append("/").append(cggCd);
+      if (bldgUsg != null && !bldgUsg.isEmpty()) {
+        path.append("/").append(bldgUsg);
+      }
+      return baseUrl + path;
     }
 
     private List<Long> parseJeonseAmounts(JsonNode root, String cutoffDate,

--- a/src/main/java/com/example/homeprotect/controller/AnalysisController.java
+++ b/src/main/java/com/example/homeprotect/controller/AnalysisController.java
@@ -3,7 +3,9 @@ package com.example.homeprotect.controller;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+
 import org.springframework.http.ResponseEntity;
+
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +24,7 @@ public class AnalysisController {
     private final AnalysisService analysisService;
 
     public AnalysisController(AnalysisService analysisService) {
-        this.analysisService = analysisService;
+      this.analysisService = analysisService;
     }
 
     @PostMapping("/init")
@@ -41,4 +43,5 @@ public class AnalysisController {
                     return ResponseEntity.ok(response);
                 });
     }
+
 }

--- a/src/main/java/com/example/homeprotect/controller/AnalysisDevController.java
+++ b/src/main/java/com/example/homeprotect/controller/AnalysisDevController.java
@@ -1,0 +1,43 @@
+package com.example.homeprotect.controller;
+
+import com.example.homeprotect.util.RedisUtil;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@Profile("dev")
+@RestController
+@RequestMapping("/analysis/dev")
+public class AnalysisDevController {
+
+  private final RedisUtil redisUtil;
+
+  public AnalysisDevController(RedisUtil redisUtil) {
+    this.redisUtil = redisUtil;
+  }
+
+  @GetMapping("/{sessionId}/jeonse")
+  public Mono<ResponseEntity<Object>> getJeonseDebug(@PathVariable String sessionId) {
+    return redisUtil.getJeonseRatio(sessionId)
+        .map(data -> ResponseEntity.ok((Object) data))
+        .onErrorReturn(ResponseEntity.notFound().build());
+  }
+
+  @GetMapping("/{sessionId}/building")
+  public Mono<ResponseEntity<Object>> getBuildingDebug(@PathVariable String sessionId) {
+    return redisUtil.getBuildingInfo(sessionId)
+        .map(data -> ResponseEntity.ok((Object) data))
+        .onErrorReturn(ResponseEntity.notFound().build());
+  }
+
+  @GetMapping("/{sessionId}/init")
+  public Mono<ResponseEntity<Object>> getInitDebug(@PathVariable String sessionId) {
+    return redisUtil.getInitSession(sessionId)
+        .map(data -> ResponseEntity.ok((Object) data))
+        .onErrorReturn(ResponseEntity.notFound().build());
+  }
+}

--- a/src/main/java/com/example/homeprotect/dto/redis/InitSessionData.java
+++ b/src/main/java/com/example/homeprotect/dto/redis/InitSessionData.java
@@ -13,6 +13,7 @@ public class InitSessionData {
     private String ocrSessionId;
     private String address;
     private String admCd;
+    private String bdMgtSn;
     private String rnMgtSn;
     private String mno;
     private String sno;
@@ -20,6 +21,7 @@ public class InitSessionData {
     private Long monthlyRent;
     private String contractType;
     private ContractPeriod contractPeriod;
+
 
     @Getter
     @Builder

--- a/src/main/java/com/example/homeprotect/dto/request/AnalysisInitRequest.java
+++ b/src/main/java/com/example/homeprotect/dto/request/AnalysisInitRequest.java
@@ -15,6 +15,7 @@ public class AnalysisInitRequest {
 
     private String address;
     private String admCd;
+    private String bdMgtSn;
     private String rnMgtSn;
     private String mno;
     private String sno;

--- a/src/main/java/com/example/homeprotect/dto/response/AddressResponse.java
+++ b/src/main/java/com/example/homeprotect/dto/response/AddressResponse.java
@@ -11,6 +11,7 @@ public class AddressResponse {
     private String jibunAddress;
     private String buildingName;
     private String admCd;
+    private String bdMgtSn;
     private String rnMgtSn;
     private String mno;
     private String sno;

--- a/src/main/java/com/example/homeprotect/dto/response/BuildingResponse.java
+++ b/src/main/java/com/example/homeprotect/dto/response/BuildingResponse.java
@@ -1,0 +1,22 @@
+package com.example.homeprotect.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+public class BuildingResponse {
+
+    private String level;
+    private String primaryUse;
+    private Boolean isResidential;
+    private Boolean violation;
+    private String approvedDate;
+    private Boolean redevelopmentZone;
+}

--- a/src/main/java/com/example/homeprotect/exception/ErrorCode.java
+++ b/src/main/java/com/example/homeprotect/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     API_UNAVAILABLE(503, "공공데이터 서버가 일시적으로 응답하지 않아요. 잠시 후 다시 시도해주세요."),
     ANALYSIS_TIMEOUT(504, "분석 시간이 너무 오래 걸리고 있어요. 다시 시도해주세요."),
     INVALID_ADDRESS(400, "입력하신 주소로 건축물대장을 조회할 수 없어요. 주소를 다시 확인해주세요."),
+    BUILDING_INFO_NOT_FOUND(404, "해당 주소의 건축물대장 정보를 찾을 수 없어요. 주소를 다시 확인해주세요."),
     AI_PARSE_FAILED(502, "AI 분석 중 오류가 발생했어요. 다시 시도해주세요."),
     INVALID_CONTRACT_TYPE(400, "계약 유형이 올바르지 않아요. (jeonse / half_jeonse / monthly)"),
 

--- a/src/main/java/com/example/homeprotect/service/AddressService.java
+++ b/src/main/java/com/example/homeprotect/service/AddressService.java
@@ -96,6 +96,7 @@ public class AddressService {
                 .rnMgtSn(juso.path("rnMgtSn").asText())
                 .mno(String.format("%04d", juso.path("buldMnnm").asInt()))  // 추가
                 .sno(String.format("%04d", juso.path("buldSlno").asInt()))  // 추가
+                .bdMgtSn(juso.path("bdMgtSn").asText())
                 .build());
         }
         return results;

--- a/src/main/java/com/example/homeprotect/service/AnalysisService.java
+++ b/src/main/java/com/example/homeprotect/service/AnalysisService.java
@@ -52,7 +52,7 @@ public class AnalysisService {
                 .contractPeriod(request.getContractPeriod())
                 .build();
       return redisUtil.saveInitSession(sessionData)
-          .doOnTerminate(() -> {
+          .doOnSuccess(ignored -> {
             jeonseRatioService.calculateAndSave(sessionData)
                 .onErrorResume(e -> {
                   log.error("전세가율 백그라운드 계산 실패 [{}]: {}", sessionData.getSessionId(), e.getMessage());

--- a/src/main/java/com/example/homeprotect/service/AnalysisService.java
+++ b/src/main/java/com/example/homeprotect/service/AnalysisService.java
@@ -24,10 +24,13 @@ public class AnalysisService {
 
     private final RedisUtil redisUtil;
     private final JeonseRatioService jeonseRatioService;
+    private final BuildingService buildingService;
 
-    public AnalysisService(RedisUtil redisUtil, JeonseRatioService jeonseRatioService) {
+    public AnalysisService(RedisUtil redisUtil, JeonseRatioService jeonseRatioService,
+                           BuildingService buildingService) {
         this.redisUtil = redisUtil;
         this.jeonseRatioService = jeonseRatioService;
+        this.buildingService = buildingService;
     }
 
     public Mono<String> initAnalysis(AnalysisInitRequest request, String ocrSessionId) {
@@ -39,6 +42,7 @@ public class AnalysisService {
                 .ocrSessionId(ocrSessionId)
                 .address(request.getAddress())
                 .admCd(request.getAdmCd())
+                .bdMgtSn(request.getBdMgtSn())
                 .rnMgtSn(request.getRnMgtSn())
                 .mno(request.getMno())
                 .sno(request.getSno())
@@ -47,17 +51,24 @@ public class AnalysisService {
                 .contractType(request.getContractType())
                 .contractPeriod(request.getContractPeriod())
                 .build();
-        return redisUtil.saveInitSession(sessionData)
-                .doOnSuccess(v ->
-                        jeonseRatioService.calculateAndSave(sessionData)
-                                .onErrorResume(e -> {
-                                    log.error("전세가율 백그라운드 계산 실패 [{}]: {}",
-                                            sessionData.getSessionId(), e.getMessage());
-                                    return Mono.empty();
-                                })
-                                .subscribeOn(Schedulers.boundedElastic())
-                                .subscribe()
-                )
-                .thenReturn(sessionData.getSessionId());
+      return redisUtil.saveInitSession(sessionData)
+          .doOnTerminate(() -> {
+            jeonseRatioService.calculateAndSave(sessionData)
+                .onErrorResume(e -> {
+                  log.error("전세가율 백그라운드 계산 실패 [{}]: {}", sessionData.getSessionId(), e.getMessage());
+                  return Mono.empty();
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+
+            buildingService.calculateAndSave(sessionData)
+                .onErrorResume(e -> {
+                  log.error("건축물 정보 백그라운드 조회 실패 [{}]: {}", sessionData.getSessionId(), e.getMessage());
+                  return Mono.empty();
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+          })
+          .thenReturn(sessionData.getSessionId());
     }
 }

--- a/src/main/java/com/example/homeprotect/service/BuildingService.java
+++ b/src/main/java/com/example/homeprotect/service/BuildingService.java
@@ -1,5 +1,6 @@
 package com.example.homeprotect.service;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
@@ -33,7 +34,7 @@ public class BuildingService {
 
     public Mono<Void> calculateAndSave(InitSessionData sessionData) {
         String bdMgtSn = sessionData.getBdMgtSn();
-        if (bdMgtSn == null || bdMgtSn.length() < 10) {
+        if (bdMgtSn == null || bdMgtSn.length() < 19) {
             return Mono.error(new HomeProtectException(ErrorCode.INVALID_ADDRESS));
         }
         String sigunguCd = bdMgtSn.substring(0, 5);
@@ -44,20 +45,24 @@ public class BuildingService {
         return Mono.zip(
             buildingApiClient.fetchTitleItem(sigunguCd, bjdongCd, bun, ji),
             buildingApiClient.fetchIsRedevelopmentZone(sigunguCd, bjdongCd, bun, ji)
+                .map(Optional::of)
+                .onErrorResume(e -> Mono.just(Optional.empty()))
         ).flatMap(tuple -> {
-            BuildingResponse response = buildResponse(tuple.getT1(), tuple.getT2());
+            BuildingResponse response = buildResponse(tuple.getT1(), tuple.getT2().orElse(null));
             return redisUtil.saveBuildingInfo(sessionData.getSessionId(), response);
         });
     }
 
-    private BuildingResponse buildResponse(JsonNode titleItem, boolean isRedevelopmentZone) {
+    private BuildingResponse buildResponse(JsonNode titleItem, Boolean isRedevelopmentZone) {
         String primaryUse = titleItem.path("mainPurpsCdNm").asText("");
         String useAprDay = titleItem.path("useAprDay").asText("");
 
         return BuildingResponse.builder()
             .level(resolveLevel(primaryUse))
             .primaryUse(primaryUse.isEmpty() ? null : primaryUse)
-            .isResidential(SAFE_USES.contains(primaryUse))
+            .isResidential(SAFE_USES.stream().anyMatch(primaryUse::contains))
+//        표제부 API 응답에 위반건축물 필드(violViolBldCd/violViolBldYmd)가 포함되지 않아
+//       현재는 false로 고정합니다. 다른 데이터 소스를 통해 파싱이 가능해지면 구현 필요.
             .violation(false)
             .approvedDate(formatApprovedDate(useAprDay))
             .redevelopmentZone(isRedevelopmentZone)
@@ -65,8 +70,8 @@ public class BuildingService {
     }
 
     private String resolveLevel(String primaryUse) {
-        if (SAFE_USES.contains(primaryUse)) return "safe";
-        if (DANGER_USES.contains(primaryUse)) return "danger";
+        if (SAFE_USES.stream().anyMatch(primaryUse::contains)) return "safe";
+        if (DANGER_USES.stream().anyMatch(primaryUse::contains)) return "danger";
         return "caution";
     }
 

--- a/src/main/java/com/example/homeprotect/service/BuildingService.java
+++ b/src/main/java/com/example/homeprotect/service/BuildingService.java
@@ -1,0 +1,82 @@
+package com.example.homeprotect.service;
+
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import com.example.homeprotect.client.BuildingApiClient;
+import com.example.homeprotect.dto.redis.InitSessionData;
+import com.example.homeprotect.dto.response.BuildingResponse;
+import com.example.homeprotect.exception.ErrorCode;
+import com.example.homeprotect.exception.HomeProtectException;
+import com.example.homeprotect.util.RedisUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import reactor.core.publisher.Mono;
+
+@Service
+public class BuildingService {
+
+    private static final Set<String> SAFE_USES =
+        Set.of("아파트", "공동주택", "다세대주택", "단독주택", "다가구주택", "연립주택");
+    private static final Set<String> DANGER_USES =
+        Set.of("근린생활시설", "제1종 근린생활시설", "제2종 근린생활시설",
+               "업무시설", "공장", "창고시설", "위험물저장및처리시설");
+
+    private final BuildingApiClient buildingApiClient;
+    private final RedisUtil redisUtil;
+
+    public BuildingService(BuildingApiClient buildingApiClient, RedisUtil redisUtil) {
+        this.buildingApiClient = buildingApiClient;
+        this.redisUtil = redisUtil;
+    }
+
+    public Mono<Void> calculateAndSave(InitSessionData sessionData) {
+        String bdMgtSn = sessionData.getBdMgtSn();
+        if (bdMgtSn == null || bdMgtSn.length() < 10) {
+            return Mono.error(new HomeProtectException(ErrorCode.INVALID_ADDRESS));
+        }
+        String sigunguCd = bdMgtSn.substring(0, 5);
+        String bjdongCd = bdMgtSn.substring(5, 10);
+        String bun = bdMgtSn.substring(11, 15);  // 지번 본번
+        String ji = bdMgtSn.substring(15, 19);   // 지번 부번
+
+        return Mono.zip(
+            buildingApiClient.fetchTitleItem(sigunguCd, bjdongCd, bun, ji),
+            buildingApiClient.fetchIsRedevelopmentZone(sigunguCd, bjdongCd, bun, ji)
+        ).flatMap(tuple -> {
+            BuildingResponse response = buildResponse(tuple.getT1(), tuple.getT2());
+            return redisUtil.saveBuildingInfo(sessionData.getSessionId(), response);
+        });
+    }
+
+    private BuildingResponse buildResponse(JsonNode titleItem, boolean isRedevelopmentZone) {
+        String primaryUse = titleItem.path("mainPurpsCdNm").asText("");
+        String useAprDay = titleItem.path("useAprDay").asText("");
+
+        return BuildingResponse.builder()
+            .level(resolveLevel(primaryUse))
+            .primaryUse(primaryUse.isEmpty() ? null : primaryUse)
+            .isResidential(SAFE_USES.contains(primaryUse))
+            .violation(false)
+            .approvedDate(formatApprovedDate(useAprDay))
+            .redevelopmentZone(isRedevelopmentZone)
+            .build();
+    }
+
+    private String resolveLevel(String primaryUse) {
+        if (SAFE_USES.contains(primaryUse)) return "safe";
+        if (DANGER_USES.contains(primaryUse)) return "danger";
+        return "caution";
+    }
+
+    private String formatApprovedDate(String useAprDay) {
+        if (useAprDay == null || useAprDay.length() < 8) return null;
+        return useAprDay.substring(0, 4) + "-" + useAprDay.substring(4, 6) + "-" + useAprDay.substring(6, 8);
+    }
+
+    private String padFour(String value) {
+        if (value == null || value.isBlank()) return "0000";
+        return String.format("%04d", Integer.parseInt(value));
+    }
+}

--- a/src/main/java/com/example/homeprotect/util/RedisUtil.java
+++ b/src/main/java/com/example/homeprotect/util/RedisUtil.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.example.homeprotect.dto.redis.InitSessionData;
 import com.example.homeprotect.dto.redis.OcrSessionData;
+import com.example.homeprotect.dto.response.BuildingResponse;
 import com.example.homeprotect.dto.response.JeonseRatioResponse;
 import com.example.homeprotect.exception.ErrorCode;
 import com.example.homeprotect.exception.HomeProtectException;
@@ -21,6 +22,7 @@ public class RedisUtil {
     private static final String OCR_KEY_PREFIX = "ocr:";
     private static final String INIT_KEY_PREFIX = "init:";
     private static final String JEONSE_RATIO_KEY_PREFIX = "jeonseRatio:";
+    private static final String BUILDING_KEY_PREFIX = "building:";
     private static final Duration OCR_TTL = Duration.ofMinutes(30);
 
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
@@ -57,6 +59,20 @@ public class RedisUtil {
         return serialize(response)
                 .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
                 .then();
+    }
+
+    public Mono<Void> saveBuildingInfo(String sessionId, BuildingResponse response) {
+        String key = BUILDING_KEY_PREFIX + sessionId;
+        return serialize(response)
+                .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+                .then();
+    }
+
+    public Mono<BuildingResponse> getBuildingInfo(String sessionId) {
+        String key = BUILDING_KEY_PREFIX + sessionId;
+        return reactiveRedisTemplate.opsForValue().get(key)
+                .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
+                .flatMap(json -> deserialize(json, BuildingResponse.class));
     }
 
     public Mono<JeonseRatioResponse> getJeonseRatio(String sessionId) {


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #18 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 2
- 실제 작업 시간 : 4

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.


건축물대장 API 호출 구현
building 필드 파싱 구현
<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- 건축물대장 조회가 항상 실패하는 문제
- 주소 코드 불일치: 가장 오래 걸린 부분.
   행안부 주소 API → admCd (행정동 기준)
   국토부 건축물대장 API → bjdongCd (법정동 기준)
   두 코드 체계가 달라서 admCd를 그대로 쓰면 totalCount=0으로 응답.
   bdMgtSn(건물관리번호)을 파싱해서 법정동 기반 코드를 추출하는 방식으로 해결.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 건축물대장 정보 조회 및 재개발 구역 판정 기능 추가
  * 분석 결과에 건축물 용도, 층수, 승인일, 위반 여부 및 재개발 여부 포함
  * 분석 세션에 건축물 정보 저장·조회 지원

* **Refactor**
  * 외부 API 요청 URL 구성 방식 개선

* **API 변경**
  * 요청/응답에 bdMgtSn 필드 추가
  * 건축물 정보 없음에 대한 사용자용 오류 메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->