### PR TITLE
[feat] 독소부분 확인 후 Pinecone 판례 벡터 검색 구현 (#27)

### DIFF
--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -52,6 +52,10 @@ jobs:
           CLOVA_KEY: ${{ secrets.CLOVA_OCR_SECRET_KEY }}
           GEMINI_KEY: ${{ secrets.GEMINI_API_KEY }}
           CLAUDE_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          PINECONE_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_HOST: ${{ secrets.PINECONE_HOST }}
+          PINECONE_INDEX: ${{ secrets.PINECONE_INDEX }}
+          PINECONE_NAMESPACE: ${{ secrets.PINECONE_NAMESPACE }}
         run: |
           set -euo pipefail
           : "${MOIS_KEY:?EXTERNAL_MOIS_ADDRESS_KEY secret is missing}"
@@ -62,6 +66,10 @@ jobs:
           : "${CLOVA_KEY:?CLOVA_OCR_SECRET_KEY secret is missing}"
           : "${GEMINI_KEY:?GEMINI_API_KEY secret is missing}"
           : "${CLAUDE_KEY:?CLAUDE_API_KEY secret is missing}"
+          : "${PINECONE_KEY:?PINECONE_API_KEY secret is missing}"
+          : "${PINECONE_HOST:?PINECONE_HOST secret is missing}"
+          : "${PINECONE_INDEX:?PINECONE_INDEX secret is missing}"
+          : "${PINECONE_NAMESPACE:?PINECONE_NAMESPACE secret is missing}"
           
           jq --arg mois "$MOIS_KEY" \
              --arg trade "$SEOUL_TRADE_KEY" \
@@ -71,6 +79,10 @@ jobs:
              --arg clova_key "$CLOVA_KEY" \
              --arg gemini "$GEMINI_KEY" \
              --arg claude "$CLAUDE_KEY" \
+             --arg pinecone_key "$PINECONE_KEY" \
+             --arg pinecone_host "$PINECONE_HOST" \
+             --arg pinecone_index "$PINECONE_INDEX" \
+             --arg pinecone_namespace "$PINECONE_NAMESPACE" \
              '(.containerDefinitions[0].environment[] | select(.name == "EXTERNAL_MOIS_ADDRESS_KEY")).value = $mois |
               (.containerDefinitions[0].environment[] | select(.name == "EXTERNAL_SEOUL_REAL_TRADE_KEY")).value = $trade |
               (.containerDefinitions[0].environment[] | select(.name == "EXTERNAL_MOLIT_BUILDING_KEY")).value = $molit |
@@ -78,7 +90,11 @@ jobs:
               (.containerDefinitions[0].environment[] | select(.name == "CLOVA_OCR_API_URL")).value = $clova_url |
               (.containerDefinitions[0].environment[] | select(.name == "CLOVA_OCR_SECRET_KEY")).value = $clova_key |
               (.containerDefinitions[0].environment[] | select(.name == "GEMINI_API_KEY")).value = $gemini |
-              (.containerDefinitions[0].environment[] | select(.name == "CLAUDE_API_KEY")).value = $claude' \
+              (.containerDefinitions[0].environment[] | select(.name == "CLAUDE_API_KEY")).value = $claude |
+              (.containerDefinitions[0].environment[] | select(.name == "PINECONE_API_KEY")).value = $pinecone_key |
+              (.containerDefinitions[0].environment[] | select(.name == "PINECONE_HOST")).value = $pinecone_host |
+              (.containerDefinitions[0].environment[] | select(.name == "PINECONE_INDEX")).value = $pinecone_index |
+              (.containerDefinitions[0].environment[] | select(.name == "PINECONE_NAMESPACE")).value = $pinecone_namespace' \
              ecs/task-definition.json > tmp.json && mv tmp.json ecs/task-definition.json
 
       - name: Fill in the new image ID in the ECS task definition

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -40,5 +40,9 @@ jobs:
           CLOVA_OCR_SECRET_KEY: ${{ secrets.CLOVA_OCR_SECRET_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_HOST: ${{ secrets.PINECONE_HOST }}
+          PINECONE_INDEX: ${{ secrets.PINECONE_INDEX }}
+          PINECONE_NAMESPACE: ${{ secrets.PINECONE_NAMESPACE }}
         run: ./gradlew build --no-daemon
         # 컴파일 + 테스트 (둘 중 하나라도 실패하면 머지 불가)

--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -26,7 +26,11 @@
         { "name": "CLOVA_OCR_API_URL", "value": "REPLACE_CLOVA_URL" },
         { "name": "CLOVA_OCR_SECRET_KEY", "value": "REPLACE_CLOVA_KEY" },
         { "name": "GEMINI_API_KEY", "value": "REPLACE_GEMINI" },
-        { "name": "CLAUDE_API_KEY", "value": "REPLACE_CLAUDE" }
+        { "name": "CLAUDE_API_KEY", "value": "REPLACE_CLAUDE" },
+        { "name": "PINECONE_API_KEY", "value": "REPLACE_PINECONE_KEY" },
+        { "name": "PINECONE_HOST", "value": "REPLACE_PINECONE_HOST" },
+        { "name": "PINECONE_INDEX", "value": "REPLACE_PINECONE_INDEX" },
+        { "name": "PINECONE_NAMESPACE", "value": "REPLACE_PINECONE_NAMESPACE" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/src/main/java/com/example/homeprotect/client/ClaudeClient.java
+++ b/src/main/java/com/example/homeprotect/client/ClaudeClient.java
@@ -37,6 +37,7 @@ public class ClaudeClient {
         Map<String, Object> body = Map.of(
             "model", model,
             "max_tokens", maxTokens,
+            "temperature", 0,
             "messages", List.of(Map.of("role", "user", "content", prompt))
         );
 

--- a/src/main/java/com/example/homeprotect/client/VectorDbClient.java
+++ b/src/main/java/com/example/homeprotect/client/VectorDbClient.java
@@ -1,0 +1,85 @@
+package com.example.homeprotect.client;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.example.homeprotect.dto.response.PrecedentSearchResult.PrecedentMatch;
+import com.example.homeprotect.exception.ErrorCode;
+import com.example.homeprotect.exception.HomeProtectException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class VectorDbClient {
+
+  private static final Logger log = LoggerFactory.getLogger(VectorDbClient.class);
+
+  @Value("${pinecone.api.namespace}")
+  private String namespace;
+
+  private final WebClient webClient;
+
+  public VectorDbClient(@Qualifier("pineconeWebClient") WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+  public Mono<List<PrecedentMatch>> search(String text, int topK) {
+    Map<String, Object> inputs = new LinkedHashMap<>();
+    inputs.put("text", text);
+
+    Map<String, Object> query = new LinkedHashMap<>();
+    query.put("inputs", inputs);
+    query.put("top_k", topK);
+
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("query", query);
+
+    return webClient.post()
+        .uri("/records/namespaces/{namespace}/search", namespace)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(body)
+        .retrieve()
+        .onStatus(
+            status -> status.is4xxClientError() || status.is5xxServerError(),
+            response -> response.bodyToMono(String.class)
+                .doOnNext(errorBody -> log.error("Pinecone 오류 응답 body: {}", errorBody))
+                .flatMap(errorBody -> Mono.error(
+                    new HomeProtectException(ErrorCode.VECTOR_DB_FAILED)))
+        )
+        .bodyToMono(JsonNode.class)
+        .map(root -> {
+          JsonNode hits = root.path("result").path("hits");
+          List<PrecedentMatch> matches = new ArrayList<>();
+          for (JsonNode hit : hits) {
+            double score = hit.path("_score").asDouble();
+            JsonNode fields = hit.path("fields");
+            String caseNumber = fields.path("case_number").asText(hit.path("_id").asText());
+            String summary = fields.path("case_summary").asText(null);
+            matches.add(PrecedentMatch.builder()
+                .precedentId(caseNumber)
+                .score(score)
+                .summary(summary)
+                .build());
+          }
+          return matches;
+        })
+        .onErrorMap(
+            e -> !(e instanceof HomeProtectException),
+            e -> {
+              log.error("Pinecone 검색 실패: {}", e.getMessage());
+              return new HomeProtectException(ErrorCode.VECTOR_DB_FAILED, e);
+            }
+        );
+  }
+}

--- a/src/main/java/com/example/homeprotect/config/PineconeConfig.java
+++ b/src/main/java/com/example/homeprotect/config/PineconeConfig.java
@@ -1,0 +1,38 @@
+package com.example.homeprotect.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@ConditionalOnProperty(name = "pinecone.api.api-key")
+@EnableConfigurationProperties(PineconeConfig.PineconeProperties.class)
+public class PineconeConfig {
+
+    private static final String API_KEY_HEADER = "Api-Key";
+
+    @ConfigurationProperties(prefix = "pinecone.api")
+    public record PineconeProperties(String apiKey, String host, String index, String namespace, int timeout) {}
+
+    private final PineconeProperties properties;
+
+    public PineconeConfig(PineconeProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean(name = "pineconeWebClient")
+    public WebClient pineconeWebClient(WebClient.Builder webClientBuilder) {
+        return webClientBuilder
+            .clone()
+            .baseUrl(properties.host())
+            .defaultHeader(API_KEY_HEADER, properties.apiKey())
+            .defaultHeader("X-Pinecone-API-Version", "2025-04")
+            .clientConnector(new ReactorClientHttpConnector(
+                WebClientConfig.buildHttpClient(5_000, properties.timeout())))
+            .build();
+    }
+}

--- a/src/main/java/com/example/homeprotect/controller/AnalysisDevController.java
+++ b/src/main/java/com/example/homeprotect/controller/AnalysisDevController.java
@@ -1,10 +1,12 @@
 package com.example.homeprotect.controller;
 
+import com.example.homeprotect.filter.RiskClauseAnalyzer;
 import jakarta.validation.Valid;
 
 import com.example.homeprotect.dto.request.ContractAnalysisRequestDto;
 import com.example.homeprotect.dto.request.RegistryAnalysisRequestDto;
 import com.example.homeprotect.service.ContractService;
+import com.example.homeprotect.service.PrecedentService;
 import com.example.homeprotect.service.RegistryService;
 import com.example.homeprotect.util.RedisUtil;
 import org.springframework.context.annotation.Profile;
@@ -25,11 +27,17 @@ public class AnalysisDevController {
   private final RedisUtil redisUtil;
   private final RegistryService registryService;
   private final ContractService contractService;
+  private final PrecedentService precedentService;
+  private final RiskClauseAnalyzer riskClauseAnalyzer;
 
-  public AnalysisDevController(RedisUtil redisUtil, RegistryService registryService, ContractService contractService) {
+  public AnalysisDevController(RedisUtil redisUtil, RegistryService registryService,
+      ContractService contractService, PrecedentService precedentService,
+      RiskClauseAnalyzer riskClauseAnalyzer) {
     this.redisUtil = redisUtil;
     this.registryService = registryService;
     this.contractService = contractService;
+    this.precedentService = precedentService;
+    this.riskClauseAnalyzer = riskClauseAnalyzer;
   }
 
   @GetMapping("/{sessionId}/jeonse")
@@ -64,6 +72,21 @@ public class AnalysisDevController {
   public Mono<ResponseEntity<Object>> extractContractClauses(
       @Valid @RequestBody ContractAnalysisRequestDto request) {
     return contractService.analyze(request.getDocumentId())
+        .map(result -> ResponseEntity.ok((Object) result));
+  }
+
+  @PostMapping("/contract/precedents")
+  public Mono<ResponseEntity<Object>> searchPrecedents(
+      @Valid @RequestBody ContractAnalysisRequestDto request) {
+    return precedentService.search(request.getDocumentId())
+        .map(result -> ResponseEntity.ok((Object) result));
+  }
+
+  @PostMapping("/contract/risk-clauses")
+  public Mono<ResponseEntity<Object>> extractRiskClauses(
+      @Valid @RequestBody ContractAnalysisRequestDto request) {
+    return redisUtil.getClauseResult(request.getDocumentId())
+        .flatMap(clauseResult -> riskClauseAnalyzer.analyze(clauseResult.getClauses()))
         .map(result -> ResponseEntity.ok((Object) result));
   }
 }

--- a/src/main/java/com/example/homeprotect/dto/response/PrecedentSearchResult.java
+++ b/src/main/java/com/example/homeprotect/dto/response/PrecedentSearchResult.java
@@ -1,0 +1,31 @@
+package com.example.homeprotect.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrecedentSearchResult {
+
+    private Integer clauseIndex;
+    private String section;
+    private String originalText;
+    private String level;  // "danger" or "caution"
+    private List<PrecedentMatch> matches;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PrecedentMatch {
+        private String precedentId;
+        private double score;
+        private String summary;
+    }
+}

--- a/src/main/java/com/example/homeprotect/exception/ErrorCode.java
+++ b/src/main/java/com/example/homeprotect/exception/ErrorCode.java
@@ -24,12 +24,14 @@ public enum ErrorCode {
     // 세션 관련
     SESSION_EXPIRED(404, "분석 결과가 만료되었어요. (30분 초과) 처음부터 다시 분석해주세요."),
     SESSION_NOT_FOUND(404, "세션 정보를 찾을 수 없어요. 처음부터 다시 시도해주세요."),
+    CLAUSE_NOT_ANALYZED(400, "조항 분석을 먼저 완료해주세요."),
 
     // AI 클라이언트
     CLAUDE_CALL_FAILED(502, "Claude API 호출에 실패했습니다."),
     GEMINI_CALL_FAILED(502, "Gemini API 호출에 실패했습니다."),
 
     // 인프라
+    EMBEDDING_FAILED(502, "임베딩 변환에 실패했습니다."),
     VECTOR_DB_FAILED(500, "판례 검색에 실패했습니다."),
 
     // 공통

--- a/src/main/java/com/example/homeprotect/filter/RiskClauseAnalyzer.java
+++ b/src/main/java/com/example/homeprotect/filter/RiskClauseAnalyzer.java
@@ -1,0 +1,91 @@
+package com.example.homeprotect.filter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.example.homeprotect.client.ClaudeClient;
+import com.example.homeprotect.dto.response.ContractClauseResult.Clause;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class RiskClauseAnalyzer {
+
+  private static final Logger log = LoggerFactory.getLogger(RiskClauseAnalyzer.class);
+
+  private static final String PROMPT_TEMPLATE = """
+            당신은 한국 임대차계약서를 분석하는 전문가입니다.
+            아래 조항 목록을 검토하여 임차인에게 불리하거나 불공정한 조항의 index만 추출하세요.
+            [주의]
+            - 판단 기준에 명확히 해당하는 조항만 포함할 것
+            - 애매한 경우 포함하지 말 것
+            - 표준 임대차 계약서에 공통적으로 포함되는 조항은 제외할 것
+
+            [판단 기준]
+            - 법적으로 무효이거나 강행규정에 위반되는 조항
+            - 임차인의 권리를 일방적으로 제한하는 조항
+            - 임대인에게만 유리한 조항
+            - 임차인이 인지하지 못할 수 있는 불리한 조건
+
+            [출력 형식] - 반드시 JSON만 출력, 다른 텍스트 절대 출력 금지
+            {"riskIndexes": [1, 3, 5]}
+
+            [조항 목록]
+            {{CLAUSES}}
+            """;
+
+  private final ClaudeClient claudeClient;
+  private final ObjectMapper objectMapper;
+
+  public RiskClauseAnalyzer(ClaudeClient claudeClient, ObjectMapper objectMapper) {
+    this.claudeClient = claudeClient;
+    this.objectMapper = objectMapper;
+  }
+
+  public Mono<List<Clause>> analyze(List<Clause> clauses) {
+    if (clauses == null || clauses.isEmpty()) {
+      return Mono.just(List.of());
+    }
+
+    String clauseText = clauses.stream()
+        .map(c -> c.getIndex() + ". [" + c.getSection() + "] " + c.getOriginalText())
+        .collect(java.util.stream.Collectors.joining("\n"));
+
+    String prompt = PROMPT_TEMPLATE.replace("{{CLAUSES}}", clauseText);
+
+    return claudeClient.generate(prompt)
+        .map(response -> {
+          try {
+            String json = stripMarkdown(response);
+            JsonNode root = objectMapper.readTree(json);
+            Set<Integer> riskIndexes = new HashSet<>();
+            root.path("riskIndexes").forEach(n -> riskIndexes.add(n.asInt()));
+            return clauses.stream()
+                .filter(c -> riskIndexes.contains(c.getIndex()))
+                .toList();
+          } catch (Exception e) {
+            log.error("RiskClauseAnalyzer 파싱 실패, 전체 조항 반환: {}", e.getMessage());
+            return clauses;
+          }
+        });
+  }
+
+  private String stripMarkdown(String text) {
+    String stripped = text.strip();
+    if (stripped.startsWith("```")) {
+      int firstNewline = stripped.indexOf('\n');
+      int lastFence = stripped.lastIndexOf("```");
+      if (firstNewline != -1 && lastFence > firstNewline) {
+        return stripped.substring(firstNewline + 1, lastFence).strip();
+      }
+    }
+    return stripped;
+  }
+}

--- a/src/main/java/com/example/homeprotect/filter/RiskClauseAnalyzer.java
+++ b/src/main/java/com/example/homeprotect/filter/RiskClauseAnalyzer.java
@@ -71,8 +71,8 @@ public class RiskClauseAnalyzer {
                 .filter(c -> riskIndexes.contains(c.getIndex()))
                 .toList();
           } catch (Exception e) {
-            log.error("RiskClauseAnalyzer 파싱 실패, 전체 조항 반환: {}", e.getMessage());
-            return clauses;
+            log.error("RiskClauseAnalyzer 파싱 실패", e);
+            return List.of();
           }
         });
   }

--- a/src/main/java/com/example/homeprotect/service/ContractService.java
+++ b/src/main/java/com/example/homeprotect/service/ContractService.java
@@ -73,7 +73,8 @@ public class ContractService {
                 String prompt = CONTRACT_PROMPT_TEMPLATE.replace("{{RAW_TEXT}}", rawText);
                 return claudeClient.generate(prompt);
             })
-            .map(this::parseResult);
+            .map(this::parseResult)
+            .flatMap(result -> redisUtil.saveClauseResult(documentId, result).thenReturn(result));
     }
 
     private ContractClauseResult parseResult(String responseText) {

--- a/src/main/java/com/example/homeprotect/service/PrecedentService.java
+++ b/src/main/java/com/example/homeprotect/service/PrecedentService.java
@@ -54,6 +54,7 @@ public class PrecedentService {
                             .flatMapSequential(clause ->
                                 vectorDbClient.search(clause.getOriginalText(), TOP_K)
                                     .map(matches -> buildResult(clause, matches))
+                                    .onErrorResume(e -> Mono.just(buildResult(clause, List.of())))
                             )
                             .collectList();
                     })

--- a/src/main/java/com/example/homeprotect/service/PrecedentService.java
+++ b/src/main/java/com/example/homeprotect/service/PrecedentService.java
@@ -1,0 +1,78 @@
+package com.example.homeprotect.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.homeprotect.client.VectorDbClient;
+import com.example.homeprotect.dto.response.ContractClauseResult.Clause;
+import com.example.homeprotect.dto.response.PrecedentSearchResult;
+import com.example.homeprotect.dto.response.PrecedentSearchResult.PrecedentMatch;
+import com.example.homeprotect.filter.RiskClauseAnalyzer;
+import com.example.homeprotect.util.RedisUtil;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class PrecedentService {
+
+    private static final double MIN_SCORE = 0.80;
+    private static final int TOP_K = 3;
+
+    private final RedisUtil redisUtil;
+    private final RiskClauseAnalyzer riskClauseAnalyzer;
+    private final VectorDbClient vectorDbClient;
+
+    public PrecedentService(
+        RedisUtil redisUtil,
+        RiskClauseAnalyzer riskClauseAnalyzer,
+        VectorDbClient vectorDbClient
+    ) {
+        this.redisUtil = redisUtil;
+        this.riskClauseAnalyzer = riskClauseAnalyzer;
+        this.vectorDbClient = vectorDbClient;
+    }
+
+    public Mono<List<PrecedentSearchResult>> search(String documentId) {
+        return redisUtil.getClauseResult(documentId)
+            .flatMap(clauseResult ->
+                // Redis 캐시 있으면 재사용, 없으면 Claude 호출 후 저장
+                redisUtil.getRiskClauses(documentId)
+                    .switchIfEmpty(
+                        riskClauseAnalyzer.analyze(clauseResult.getClauses())
+                            .flatMap(riskClauses ->
+                                redisUtil.saveRiskClauses(documentId, riskClauses)
+                                    .thenReturn(riskClauses)
+                            )
+                    )
+                    .flatMap(riskClauses -> {
+                        if (riskClauses.isEmpty()) {
+                            return Mono.just(List.of());
+                        }
+                        return Flux.fromIterable(riskClauses)
+                            .flatMapSequential(clause ->
+                                vectorDbClient.search(clause.getOriginalText(), TOP_K)
+                                    .map(matches -> buildResult(clause, matches))
+                            )
+                            .collectList();
+                    })
+            );
+    }
+
+    private PrecedentSearchResult buildResult(Clause clause, List<PrecedentMatch> matches) {
+        List<PrecedentMatch> qualified = matches.stream()
+            .filter(m -> m.getScore() >= MIN_SCORE)
+            .toList();
+
+        String level = qualified.isEmpty() ? "caution" : "danger";
+
+        return PrecedentSearchResult.builder()
+            .clauseIndex(clause.getIndex())
+            .section(clause.getSection())
+            .originalText(clause.getOriginalText())
+            .level(level)
+            .matches(qualified)
+            .build();
+    }
+}

--- a/src/main/java/com/example/homeprotect/service/PrecedentService.java
+++ b/src/main/java/com/example/homeprotect/service/PrecedentService.java
@@ -42,8 +42,10 @@ public class PrecedentService {
                     .switchIfEmpty(
                         riskClauseAnalyzer.analyze(clauseResult.getClauses())
                             .flatMap(riskClauses ->
-                                redisUtil.saveRiskClauses(documentId, riskClauses)
-                                    .thenReturn(riskClauses)
+                                riskClauses.isEmpty()
+                                    ? Mono.just(riskClauses)
+                                    : redisUtil.saveRiskClauses(documentId, riskClauses)
+                                        .thenReturn(riskClauses)
                             )
                     )
                     .flatMap(riskClauses -> {

--- a/src/main/java/com/example/homeprotect/util/RedisUtil.java
+++ b/src/main/java/com/example/homeprotect/util/RedisUtil.java
@@ -120,7 +120,7 @@ public class RedisUtil {
                     );
                     return Mono.just(clauses);
                 } catch (JsonProcessingException e) {
-                    return Mono.error(new HomeProtectException(ErrorCode.INTERNAL_ERROR, e));
+                    return reactiveRedisTemplate.delete(key).then(Mono.empty());
                 }
             });
         // 캐시 없으면 empty 반환

--- a/src/main/java/com/example/homeprotect/util/RedisUtil.java
+++ b/src/main/java/com/example/homeprotect/util/RedisUtil.java
@@ -1,6 +1,7 @@
 package com.example.homeprotect.util;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Component;
 import com.example.homeprotect.dto.redis.InitSessionData;
 import com.example.homeprotect.dto.redis.OcrSessionData;
 import com.example.homeprotect.dto.response.BuildingResponse;
+import com.example.homeprotect.dto.response.ContractClauseResult;
+import com.example.homeprotect.dto.response.ContractClauseResult.Clause;
 import com.example.homeprotect.dto.response.JeonseRatioResponse;
 import com.example.homeprotect.exception.ErrorCode;
 import com.example.homeprotect.exception.HomeProtectException;
@@ -23,6 +26,8 @@ public class RedisUtil {
     private static final String INIT_KEY_PREFIX = "init:";
     private static final String JEONSE_RATIO_KEY_PREFIX = "jeonseRatio:";
     private static final String BUILDING_KEY_PREFIX = "building:";
+    private static final String CLAUSE_KEY_PREFIX = "clause:";
+    private static final String RISK_CLAUSES_KEY_PREFIX = "riskClauses:";
     private static final Duration OCR_TTL = Duration.ofMinutes(30);
 
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
@@ -36,57 +41,96 @@ public class RedisUtil {
     public Mono<Void> saveOcrSession(OcrSessionData data) {
         String key = OCR_KEY_PREFIX + data.getSessionId();
         return serialize(data)
-                .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
-                .then();
+            .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+            .then();
     }
 
     public Mono<Void> saveInitSession(InitSessionData data) {
         String key = INIT_KEY_PREFIX + data.getSessionId();
         return serialize(data)
-                .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
-                .then();
+            .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+            .then();
     }
 
     public Mono<InitSessionData> getInitSession(String sessionId) {
         String key = INIT_KEY_PREFIX + sessionId;
         return reactiveRedisTemplate.opsForValue().get(key)
-                .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
-                .flatMap(json -> deserialize(json, InitSessionData.class));
+            .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
+            .flatMap(json -> deserialize(json, InitSessionData.class));
     }
 
     public Mono<Void> saveJeonseRatio(String sessionId, JeonseRatioResponse response) {
         String key = JEONSE_RATIO_KEY_PREFIX + sessionId;
         return serialize(response)
-                .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
-                .then();
+            .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+            .then();
     }
 
     public Mono<Void> saveBuildingInfo(String sessionId, BuildingResponse response) {
         String key = BUILDING_KEY_PREFIX + sessionId;
         return serialize(response)
-                .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
-                .then();
+            .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+            .then();
     }
 
     public Mono<BuildingResponse> getBuildingInfo(String sessionId) {
         String key = BUILDING_KEY_PREFIX + sessionId;
         return reactiveRedisTemplate.opsForValue().get(key)
-                .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
-                .flatMap(json -> deserialize(json, BuildingResponse.class));
+            .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
+            .flatMap(json -> deserialize(json, BuildingResponse.class));
     }
 
     public Mono<JeonseRatioResponse> getJeonseRatio(String sessionId) {
         String key = JEONSE_RATIO_KEY_PREFIX + sessionId;
         return reactiveRedisTemplate.opsForValue().get(key)
-                .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
-                .flatMap(json -> deserialize(json, JeonseRatioResponse.class));
+            .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
+            .flatMap(json -> deserialize(json, JeonseRatioResponse.class));
+    }
+
+    public Mono<Void> saveClauseResult(String documentId, ContractClauseResult result) {
+        String key = CLAUSE_KEY_PREFIX + documentId;
+        return serialize(result)
+            .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+            .then();
+    }
+
+    public Mono<ContractClauseResult> getClauseResult(String documentId) {
+        String key = CLAUSE_KEY_PREFIX + documentId;
+        return reactiveRedisTemplate.opsForValue().get(key)
+            .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.CLAUSE_NOT_ANALYZED)))
+            .flatMap(json -> deserialize(json, ContractClauseResult.class));
+    }
+
+    public Mono<Void> saveRiskClauses(String documentId, List<Clause> clauses) {
+        String key = RISK_CLAUSES_KEY_PREFIX + documentId;
+        return serialize(clauses)
+            .flatMap(json -> reactiveRedisTemplate.opsForValue().set(key, json, OCR_TTL))
+            .then();
+    }
+
+    public Mono<List<Clause>> getRiskClauses(String documentId) {
+        String key = RISK_CLAUSES_KEY_PREFIX + documentId;
+        return reactiveRedisTemplate.opsForValue().get(key)
+            .flatMap(json -> {
+                try {
+                    List<Clause> clauses = objectMapper.readValue(
+                        json,
+                        objectMapper.getTypeFactory()
+                            .constructCollectionType(List.class, Clause.class)
+                    );
+                    return Mono.just(clauses);
+                } catch (JsonProcessingException e) {
+                    return Mono.error(new HomeProtectException(ErrorCode.INTERNAL_ERROR, e));
+                }
+            });
+        // 캐시 없으면 empty 반환
     }
 
     public Mono<OcrSessionData> getOcrSession(String sessionId) {
         String key = OCR_KEY_PREFIX + sessionId;
         return reactiveRedisTemplate.opsForValue().get(key)
-                .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
-                .flatMap(json -> deserialize(json, OcrSessionData.class));
+            .switchIfEmpty(Mono.error(new HomeProtectException(ErrorCode.SESSION_EXPIRED)))
+            .flatMap(json -> deserialize(json, OcrSessionData.class));
     }
 
     private <T> Mono<String> serialize(T data) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,6 +13,13 @@ claude:
   api:
     api-key: ${CLAUDE_API_KEY}
 
+pinecone:
+  api:
+    api-key: ${PINECONE_API_KEY}
+    host: ${PINECONE_HOST}
+    index: ${PINECONE_INDEX}
+    namespace: ${PINECONE_NAMESPACE}
+
 clova:
   ocr:
     api-url: ${CLOVA_OCR_API_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,10 @@ claude:
     max-tokens: 4000
     timeout: 30000
 
+pinecone:
+  api:
+    timeout: 10000
+
 public-api:
   external:
     # 1. 서울시: 부동산 실거래가 정보


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #27 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 3
- 실제 작업 시간 : 4

ai 호출 2회 에서 3회로 구성 변경으로 인한 고민
<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

Claude 1차 파싱 결과를 기반으로 2차 claude ai를 활용해 독소조항을 추출하고
해당 추출된 독소조항 인덱스를 확인해 Pinecone 벡터 DB에서 유사 판례 검색

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- 처음에는 독소조항 자체를 설정해놓은 키워드를 확인해 ( "임의", "몰수", "공제", "전액", "동의 없이",
    "통보 없이", "해지", "포기", "인상", "책임을 지지 않는다",)  판례 DB를 비교하여 독소조항을 판별하려 했으나 해당 키워드가 나오지 않아도 독소조항이 있을 수 있는 우려가 있어 ai 호출을 한 번 더 하는 것으로 결론
- ai 호출을 줄이고자 첫번째로 raw data에서 구조화된 값으로 만들어주는 역할을 하며 독소조항도 같이 추출하려 하니 해당 ai의 무게가 너무 커짐
- 결국 ai별로 역할을 세분화해 호출하는 것으로 결론
<img width="816" height="441" alt="스크린샷 2026-05-06 오전 6 40 32" src="https://github.com/user-attachments/assets/cb39cf47-73bd-400e-8991-7ad3df21b2dd" />

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 선례 사건 검색 기능 추가 — 계약서 조항과 유사한 이전 판례를 조회할 수 있습니다.
  * 계약서 위험 조항 추출 API 추가 — 위험한 조항을 별도 엔드포인트로 제공됩니다.
  * 분석 결과 및 위험 조항 캐싱 — 반복 조회 시 응답 속도 개선.

* **개선사항**
  * 벡터 DB 연동으로 선례 검색 정확도 향상
  * AI 응답의 결정성 향상으로 분석 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->