### PR TITLE
[refactor] OCR 엔드포인트 분리 및 Swagger 문서 추가 (#39)

### DIFF
--- a/src/main/java/com/example/homeprotect/controller/AnalysisController.java
+++ b/src/main/java/com/example/homeprotect/controller/AnalysisController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.homeprotect.controller.docs.AnalysisControllerDocs;
 import com.example.homeprotect.dto.request.AnalysisInitRequest;
 import com.example.homeprotect.dto.request.AnalysisRunRequest;
 import com.example.homeprotect.service.AnalysisService;
@@ -24,7 +25,7 @@ import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/analysis")
-public class AnalysisController {
+public class AnalysisController implements AnalysisControllerDocs {
 
     private final AnalysisService analysisService;
 

--- a/src/main/java/com/example/homeprotect/controller/AnalysisDevController.java
+++ b/src/main/java/com/example/homeprotect/controller/AnalysisDevController.java
@@ -11,6 +11,8 @@ import com.example.homeprotect.service.PrecedentService;
 import com.example.homeprotect.service.RegistryService;
 import com.example.homeprotect.util.RedisUtil;
 import org.springframework.context.annotation.Profile;
+
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
+@Hidden
 @Profile("dev")
 @RestController
 @RequestMapping("/analysis/dev")

--- a/src/main/java/com/example/homeprotect/controller/DocumentController.java
+++ b/src/main/java/com/example/homeprotect/controller/DocumentController.java
@@ -26,21 +26,37 @@ public class DocumentController implements DocumentControllerDocs {
         this.documentService = documentService;
     }
 
-    @PostMapping(value = "/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public Mono<ResponseEntity<Map<String, Object>>> scanDocument(
-            @RequestPart("file") FilePart file,
-            @RequestPart("docType") String docType) {
-        return documentService.scanDocument(file, docType)
+    @PostMapping(value = "/ocr/registry", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Mono<ResponseEntity<Map<String, Object>>> scanRegistry(
+            @RequestPart("file") FilePart file) {
+        return documentService.scanDocument(file, "registry")
             .map(data -> {
-              Map<String, Object> inner = new LinkedHashMap<>();
-              inner.put("sessionId", data.getSessionId());
-              inner.put("safe", data.isSafe());
+                Map<String, Object> inner = new LinkedHashMap<>();
+                inner.put("registrySessionId", data.getSessionId());
+                inner.put("safe", data.isSafe());
 
-              Map<String, Object> response = new LinkedHashMap<>();
-              response.put("status", "success");
-              response.put("data", inner);
+                Map<String, Object> response = new LinkedHashMap<>();
+                response.put("status", "success");
+                response.put("data", inner);
 
-              return ResponseEntity.ok(response);
+                return ResponseEntity.ok(response);
+            });
+    }
+
+    @PostMapping(value = "/ocr/contract", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Mono<ResponseEntity<Map<String, Object>>> scanContract(
+            @RequestPart("file") FilePart file) {
+        return documentService.scanDocument(file, "contract")
+            .map(data -> {
+                Map<String, Object> inner = new LinkedHashMap<>();
+                inner.put("contractSessionId", data.getSessionId());
+                inner.put("safe", data.isSafe());
+
+                Map<String, Object> response = new LinkedHashMap<>();
+                response.put("status", "success");
+                response.put("data", inner);
+
+                return ResponseEntity.ok(response);
             });
     }
 }

--- a/src/main/java/com/example/homeprotect/controller/docs/AnalysisControllerDocs.java
+++ b/src/main/java/com/example/homeprotect/controller/docs/AnalysisControllerDocs.java
@@ -1,0 +1,158 @@
+package com.example.homeprotect.controller.docs;
+
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.homeprotect.dto.request.AnalysisRunRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Analysis", description = "전세 안전 분석 실행 및 결과 조회 API")
+public interface AnalysisControllerDocs {
+
+    @Operation(
+        summary = "분석 실행",
+        description = """
+            등기부등본·임대차계약서 OCR 세션과 소유자 확인 여부를 받아 분석을 백그라운드로 시작합니다.
+            응답은 즉시 processing으로 반환되며, 진행 상황은 /analysis/stream SSE로 수신합니다.
+            """
+    )
+    @ApiResponse(responseCode = "200", description = "분석 시작 성공",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "success",
+                  "data": {
+                    "sessionId": "uuid-xxxx",
+                    "analysisStatus": "processing"
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "400", description = "소유자 미확인",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": 400,
+                  "code": "OWNER_NOT_VERIFIED",
+                  "message": "등기부상 소유자와 계약서상 임대인이 동일한지 확인 후 체크해주세요."
+                }
+                """)))
+    @ApiResponse(responseCode = "404", description = "세션 만료",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": 404,
+                  "code": "SESSION_EXPIRED",
+                  "message": "분석 결과가 만료되었어요. (30분 초과) 처음부터 다시 분석해주세요."
+                }
+                """)))
+    Mono<ResponseEntity<Map<String, Object>>> runAnalysis(
+        @RequestBody AnalysisRunRequest request);
+
+    @Operation(
+        summary = "분석 진행 상황 스트리밍 (SSE)",
+        description = """
+            분석 각 단계(jeonseRatio, registryParse, contractReview, buildingCheck)의 완료 여부를
+            Server-Sent Events로 실시간 수신합니다.
+            재연결 시 이미 완료된 단계는 즉시 재전송됩니다.
+
+            이벤트 형식:
+            - 단계 완료: {"step": "jeonseRatio", "status": "done"}
+            - 전체 완료: {"step": "complete"}
+            - 에러 발생: {"step": "error", "errorCode": "API_UNAVAILABLE"}
+            """
+    )
+    @ApiResponse(responseCode = "200", description = "SSE 스트림 연결 성공",
+        content = @Content(mediaType = MediaType.TEXT_EVENT_STREAM_VALUE,
+            examples = @ExampleObject(value = """
+                    data: {"step": "jeonseRatio", "status": "done"}
+
+                    data: {"step": "registryParse", "status": "done"}
+
+                    data: {"step": "contractReview", "status": "done"}
+
+                    data: {"step": "buildingCheck", "status": "done"}
+
+                    data: {"step": "complete"}
+                    """)))
+    Flux<ServerSentEvent<String>> streamAnalysisStatus(
+        @Parameter(description = "분석 세션 ID (/analysis/init 응답값)", required = true)
+        @RequestParam String sessionId);
+
+    @Operation(
+        summary = "분석 결과 조회",
+        description = "SSE에서 complete 이벤트를 수신한 후 호출하여 전체 분석 결과를 가져옵니다."
+    )
+    @ApiResponse(responseCode = "200", description = "결과 조회 성공",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "success",
+                  "data": {
+                    "address": "서울특별시 강남구 테헤란로 123",
+                    "analyzedAt": "2026-05-07T14:30:00+09:00",
+                    "jeonseRatio": {
+                      "ratioType": "jeonse",
+                      "ratioPercent": 72.5,
+                      "riskLevel": "caution",
+                      "recentHigh": 450000000,
+                      "recentLow": 320000000,
+                      "average": 385000000,
+                      "convertedDeposit": 380000000,
+                      "sampleCount": 8,
+                      "lowReliability": false
+                    },
+                    "registry": {
+                      "mortgageCount": 1,
+                      "mortgages": [
+                        { "bank": "국민은행", "amount": 200000000 }
+                      ],
+                      "totalMortgage": 200000000,
+                      "trustWarning": false,
+                      "priorLease": false,
+                      "ownershipChangeRecent": false
+                    },
+                    "building": {
+                      "level": "safe",
+                      "primaryUse": "아파트",
+                      "isResidential": true,
+                      "violation": false,
+                      "approvedDate": "2010-03-15",
+                      "redevelopmentZone": false
+                    },
+                    "contract": {
+                      "toxicClauses": [
+                        {
+                          "level": "danger",
+                          "title": "임의 해지 조항",
+                          "originalText": "임대인은 사전 통보 없이 계약을 해지할 수 있다.",
+                          "legalIssue": "임차인의 주거 안정권을 침해하는 일방적 조항입니다.",
+                          "precedent": "대법원 2019다12345",
+                          "suggestion": "해당 조항 삭제 또는 임차인 동의 요건 추가를 요구하세요."
+                        }
+                      ],
+                      "cautionClauses": []
+                    }
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "404", description = "세션 만료 또는 분석 미완료",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": 404,
+                  "code": "SESSION_EXPIRED",
+                  "message": "분석 결과가 만료되었어요. (30분 초과) 처음부터 다시 분석해주세요."
+                }
+                """)))
+    Mono<ResponseEntity<Map<String, Object>>> getAnalysisResult(
+        @Parameter(description = "분석 세션 ID (/analysis/init 응답값)", required = true)
+        @RequestParam String sessionId);
+}

--- a/src/main/java/com/example/homeprotect/controller/docs/DocumentControllerDocs.java
+++ b/src/main/java/com/example/homeprotect/controller/docs/DocumentControllerDocs.java
@@ -36,8 +36,9 @@ public interface DocumentControllerDocs {
                   }
                 }
                 """)))
-    @ApiResponse(responseCode = "400", description = "E-1: 개인정보(PII) 감지",
-        content = @Content(examples = @ExampleObject(value = """
+    @ApiResponse(responseCode = "400", description = "요청 오류 (PII 감지 또는 지원하지 않는 파일 형식)",
+        content = @Content(examples = {
+            @ExampleObject(name = "PII_DETECTED", value = """
                 {
                   "status": "error",
                   "error": {
@@ -47,9 +48,8 @@ public interface DocumentControllerDocs {
                     "nonMasked": ["주민등록번호", "전화번호"]
                   }
                 }
-                """)))
-    @ApiResponse(responseCode = "400", description = "E-2: 지원하지 않는 파일 형식",
-        content = @Content(examples = @ExampleObject(value = """
+                """),
+            @ExampleObject(name = "INVALID_FILE_TYPE", value = """
                 {
                   "status": "error",
                   "error": {
@@ -58,7 +58,8 @@ public interface DocumentControllerDocs {
                     "field": "file"
                   }
                 }
-                """)))
+                """)
+        }))
     @ApiResponse(responseCode = "422", description = "E-3: OCR 판독 실패",
         content = @Content(examples = @ExampleObject(value = """
                 {
@@ -91,8 +92,9 @@ public interface DocumentControllerDocs {
                   }
                 }
                 """)))
-    @ApiResponse(responseCode = "400", description = "E-1: 개인정보(PII) 감지",
-        content = @Content(examples = @ExampleObject(value = """
+    @ApiResponse(responseCode = "400", description = "요청 오류 (PII 감지 또는 지원하지 않는 파일 형식)",
+        content = @Content(examples = {
+            @ExampleObject(name = "PII_DETECTED", value = """
                 {
                   "status": "error",
                   "error": {
@@ -102,9 +104,8 @@ public interface DocumentControllerDocs {
                     "nonMasked": ["주민등록번호", "전화번호"]
                   }
                 }
-                """)))
-    @ApiResponse(responseCode = "400", description = "E-2: 지원하지 않는 파일 형식",
-        content = @Content(examples = @ExampleObject(value = """
+                """),
+            @ExampleObject(name = "INVALID_FILE_TYPE", value = """
                 {
                   "status": "error",
                   "error": {
@@ -113,7 +114,8 @@ public interface DocumentControllerDocs {
                     "field": "file"
                   }
                 }
-                """)))
+                """)
+        }))
     @ApiResponse(responseCode = "422", description = "E-3: OCR 판독 실패",
         content = @Content(examples = @ExampleObject(value = """
                 {

--- a/src/main/java/com/example/homeprotect/controller/docs/DocumentControllerDocs.java
+++ b/src/main/java/com/example/homeprotect/controller/docs/DocumentControllerDocs.java
@@ -19,61 +19,113 @@ import reactor.core.publisher.Mono;
 @Tag(name = "Document", description = "문서 OCR 및 개인정보 감지 API")
 public interface DocumentControllerDocs {
 
-  @Operation(
-      summary = "문서 OCR 스캔",
-      description = "등기부등본 또는 임대차계약서 이미지를 업로드하면 OCR 추출 후 개인정보 감지 결과를 반환합니다.",
-      requestBody = @RequestBody(
-          content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
-      )
-  )
-  @ApiResponse(responseCode = "200", description = "OCR 성공",
-      content = @Content(examples = @ExampleObject(value = """
-                    {
-                      "status": "success",
-                      "data": {
-                        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
-                        "safe": true
-                      }
-                    }
-                    """)))
-  @ApiResponse(responseCode = "400", description = "E-1: 개인정보(PII) 감지",
-      content = @Content(examples = @ExampleObject(value = """
-                    {
-                      "status": "error",
-                      "error": {
-                        "code": "PII_DETECTED",
-                        "message": "개인정보가 감지되었습니다. 가린 뒤 다시 업로드해주세요.",
-                        "field": "file",
-                        "nonMasked": ["주민등록번호", "전화번호"]
-                      }
-                    }
-                    """)))
+    @Operation(
+        summary = "등기부등본 OCR 스캔",
+        description = "등기부등본 이미지를 업로드하면 OCR 추출 후 개인정보 감지 결과를 반환합니다.",
+        requestBody = @RequestBody(
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+        )
+    )
+    @ApiResponse(responseCode = "200", description = "OCR 성공",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "success",
+                  "data": {
+                    "registrySessionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "safe": true
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "400", description = "E-1: 개인정보(PII) 감지",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "error",
+                  "error": {
+                    "code": "PII_DETECTED",
+                    "message": "개인정보가 감지되었습니다. 가린 뒤 다시 업로드해주세요.",
+                    "field": "file",
+                    "nonMasked": ["주민등록번호", "전화번호"]
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "400", description = "E-2: 지원하지 않는 파일 형식",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "error",
+                  "error": {
+                    "code": "INVALID_FILE_TYPE",
+                    "message": "지원하지 않는 파일 형식이에요. (jpg, jpeg, png, pdf)",
+                    "field": "file"
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "422", description = "E-3: OCR 판독 실패",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "error",
+                  "error": {
+                    "code": "OCR_FAILED",
+                    "message": "이미지를 판독할 수 없어요. 더 선명한 사진으로 다시 업로드해주세요.",
+                    "field": "file"
+                  }
+                }
+                """)))
+    Mono<ResponseEntity<Map<String, Object>>> scanRegistry(
+        @Parameter(description = "업로드할 등기부등본 파일 (jpg, jpeg, png, pdf)", required = true)
+        @RequestPart("file") FilePart file);
 
-  @ApiResponse(responseCode = "400", description = "E-2: 지원하지 않는 파일 형식",
-      content = @Content(examples = @ExampleObject(value = """
-                    {
-                      "status": "error",
-                      "error": {
-                        "code": "INVALID_FILE_TYPE",
-                        "message": "지원하지 않는 파일 형식이에요. (jpg, jpeg, png, pdf)",
-                        "field": "file"
-                      }
-                   }
-                  """)))
-  @ApiResponse(responseCode = "422", description = "E-2: OCR 판독 실패",
-      content = @Content(examples = @ExampleObject(value = """
-                    {
-                      "status": "error",
-                      "error": {
-                        "code": "OCR_FAILED",
-                        "message": "이미지를 판독할 수 없어요. 더 선명한 사진으로 다시 업로드해주세요.",
-                        "field": "file"
-                      }
-                    }
-                    """)))
-  Mono<ResponseEntity<Map<String, Object>>> scanDocument(
-      @Parameter(description = "업로드할 문서 파일 (jpg, jpeg, png, pdf)", required = true)
-      @RequestPart("file") FilePart file,
-      @Parameter(description = "문서 유형: registry(등기부등본) 또는 contract(임대차계약서)", example = "registry", required = true)
-      @RequestPart("docType") String docType);
+    @Operation(
+        summary = "임대차계약서 OCR 스캔",
+        description = "임대차계약서 이미지를 업로드하면 OCR 추출 후 개인정보 감지 결과를 반환합니다.",
+        requestBody = @RequestBody(
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+        )
+    )
+    @ApiResponse(responseCode = "200", description = "OCR 성공",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "success",
+                  "data": {
+                    "contractSessionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "safe": true
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "400", description = "E-1: 개인정보(PII) 감지",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "error",
+                  "error": {
+                    "code": "PII_DETECTED",
+                    "message": "개인정보가 감지되었습니다. 가린 뒤 다시 업로드해주세요.",
+                    "field": "file",
+                    "nonMasked": ["주민등록번호", "전화번호"]
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "400", description = "E-2: 지원하지 않는 파일 형식",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "error",
+                  "error": {
+                    "code": "INVALID_FILE_TYPE",
+                    "message": "지원하지 않는 파일 형식이에요. (jpg, jpeg, png, pdf)",
+                    "field": "file"
+                  }
+                }
+                """)))
+    @ApiResponse(responseCode = "422", description = "E-3: OCR 판독 실패",
+        content = @Content(examples = @ExampleObject(value = """
+                {
+                  "status": "error",
+                  "error": {
+                    "code": "OCR_FAILED",
+                    "message": "이미지를 판독할 수 없어요. 더 선명한 사진으로 다시 업로드해주세요.",
+                    "field": "file"
+                  }
+                }
+                """)))
+    Mono<ResponseEntity<Map<String, Object>>> scanContract(
+        @Parameter(description = "업로드할 임대차계약서 파일 (jpg, jpeg, png, pdf)", required = true)
+        @RequestPart("file") FilePart file);
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #39 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1
- 실제 작업 시간 : 1

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- /documents/ocr → /documents/ocr/registry, /documents/ocr/contract 분리
- 응답 키도 registrySessionId / contractSessionId로 명확화
- AnalysisControllerDocs, DocumentControllerDocs Swagger 추가

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="631" height="167" alt="스크린샷 2026-05-07 오후 2 14 26" src="https://github.com/user-attachments/assets/78461e69-3e7f-4cdc-934e-f445da5b3217" />
<img width="624" height="196" alt="스크린샷 2026-05-07 오후 2 14 36" src="https://github.com/user-attachments/assets/9a3b0fe0-9a51-4f21-a3cb-9dc128adcb0c" />


<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.


<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 등기부 OCR 전용 엔드포인트(`POST /documents/ocr/registry`) 추가
  * 임대차계약서 OCR 전용 엔드포인트(`POST /documents/ocr/contract`) 추가
  * 문서 유형별 고유 세션 ID 제공으로 응답 구조 개선

* **변경 사항**
  * 문서 OCR 요청 시 문서 유형 파라미터 제거로 API 사용 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->